### PR TITLE
Comment around wildcards.

### DIFF
--- a/api/routes.ts
+++ b/api/routes.ts
@@ -10,6 +10,14 @@ const router = express.Router({ mergeParams: true })
 router.use(serviceTokenMiddleware)
 router.use(authInterceptor)
 
+/**
+ * These wildcard routes are leveraged by the CCD components.
+ *
+ * Calls to /aggregated and /data are routed through here.
+ *
+ * @see ccd-case-ui-toolkit project
+ * @see application.ts
+ */
 router.get('/*', proxy.get)
 router.post('/*', proxy.post)
 router.put('/*', proxy.put)


### PR DESCRIPTION
I've taken a look at the wildcard routes in our Node Layer in greater detail- they are leveraged by the CCD components.

The config for the CCD components has the following two config properties.

"api_url": "/aggregated",
"case_data_url": "/data",

Which link through to our Node layer.

If you look at the ccd-case-ui-toolkit. The CCD component's leverage these routes, therefore we have implemented these as wildcards within our Node layer; so that it's quick to bring on new CCD components, and the CCD components are able to adjust their api calls without a change to our Node layer.