### PR TITLE
Bugfix/eui 835 csp blocking app insights

### DIFF
--- a/src/web.config
+++ b/src/web.config
@@ -9,7 +9,7 @@
             <add name="Surrogate-Control" value="no-store" />
             <add name="Pragma" value="no-cache" />
             <add name="Expires" value="0" />
-            <add name="Content-Security-Policy" value="default-src 'self'; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: *.google-analytics.com; style-src https://fonts.googleapis.com https://fonts.gstatic.com 'unsafe-inline' 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.google-analytics.com *.vo.msecnd.net; connect-src 'self' *.gov.uk; object-src 'self'; frame-ancestors 'none'" />
+            <add name="Content-Security-Policy" value="default-src 'self'; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: *.google-analytics.com; style-src https://fonts.googleapis.com https://fonts.gstatic.com 'unsafe-inline' 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.google-analytics.com *.vo.msecnd.net; connect-src 'self' *.gov.uk *.services.visualstudio.com; object-src 'self'; frame-ancestors 'none'" />
             <add name="X-Content-Type-Options" value="nosniff" />
             <add name="Strict-Transport-Security" value="max-age=31536000; preload" />
             <add name="X-Frame-Options" value="DENY" />


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-835


### Change description ###
Added AppInsights API call to CSP connect-src, otherwise CSP policy blocks this call.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
