### PR TITLE
increased upload limit to Infinity

### DIFF
--- a/api/documents/DMStore.ts
+++ b/api/documents/DMStore.ts
@@ -66,8 +66,13 @@ export async function postDocuments(fields: Fields, files: Files): Promise<DMDoc
     formData.append(field, fields[field])
   })
 
+  // we explicitly set upload limit to Infinity here, rejection is handled by dm-store
   const response: AxiosResponse<DMDocuments> = await asyncReturnOrError(
-    http.post(`${url}/documents/`, formData, { headers: formData.getHeaders() }),
+    http.post(`${url}/documents/`, formData,
+        {
+            headers: formData.getHeaders(),
+            maxContentLength: Infinity,
+        }),
     `Error posting documents`,
     null,
     logger,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-1184


### Change description ###
For document upload path only, upload has increased to Infinity. Gets around stream write errors, however the max upload size can be determined safely/rejected by dm-store.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
