### PR TITLE
EUI-2575: Update Internal Search API URL

### DIFF
--- a/api/searchCases/index.ts
+++ b/api/searchCases/index.ts
@@ -40,7 +40,7 @@ export function prepareElasticQuery(queryParams: {page?}, body: {size?, sort?}):
     const from = page * size
 
     Object.keys(metaCriteria).map(key => {
-        if (key === 'ctid' || key === 'usecase' || key === 'view' || key === 'page') {
+        if (key === 'ctid' || key === 'use_case' || key === 'view' || key === 'page') {
             delete metaCriteria[key]
         }
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@angular/platform-browser": "^7.2.13",
     "@angular/platform-browser-dynamic": "^7.2.13",
     "@angular/router": "^7.2.13",
-    "@hmcts/ccd-case-ui-toolkit": "^2.64.25-case-sharing-prerelease",
+    "@hmcts/ccd-case-ui-toolkit": "^2.64.33-internal-search-api-url-update",
     "@hmcts/ccpay-web-component": "3.0.3",
     "@hmcts/frontend": "0.0.39-alpha",
     "@hmcts/media-viewer": "2.2.7",

--- a/src/app/services/ccd-config/ccd-case.config.ts
+++ b/src/app/services/ccd-config/ccd-case.config.ts
@@ -118,4 +118,11 @@ export class AppConfig extends AbstractAppConfig {
     return `${this.getCaseDataUrl()}/internal/banners/`;
   }
 
+  public getPrdUrl(): string {
+    return 'api/caseshare/orgs';
+  }
+
+  public getCacheTimeOut(): number {
+    return 45000;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,10 +401,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hmcts/ccd-case-ui-toolkit@^2.64.25-case-sharing-prerelease":
-  version "2.64.25-case-sharing-prerelease"
-  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-2.64.25-case-sharing-prerelease.tgz#89fff5ec42aa3e48ab5c14eff5f243cdc4245ae3"
-  integrity sha512-zdpLObmgflby/PZp3QnmqC+4l9v+81bdofj0Iw/zITlEfjCo3X5O24fAOcFEV/mFL/+XfX0V21J9UBUNOdV9Ag==
+"@hmcts/ccd-case-ui-toolkit@^2.64.33-internal-search-api-url-update":
+  version "2.64.33-internal-search-api-url-update"
+  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-2.64.33-internal-search-api-url-update.tgz#cda8d321dbbda02212b04ac7cab6a5829c5e1691"
+  integrity sha512-SoauJ74mb5ug7CF6Nkw1UTlYsdIJbgwAjvkg673+zRr6glfVonirtTxhYJ9uweoYpwVOVuDVqxoFlzK0YF1qBQ==
   dependencies:
     "@angular/cli" "^6.0.8"
     "@angular/compiler-cli" "~7.0.3"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2575

### Change description ###
Upgrade to `@hmcts/ccd-case-ui-toolkit` version `2.64.33-internal-search-api-url-update`, which contains the updated URL.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
