### PR TITLE
Fix to allow the application to run in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "govuk_frontend_toolkit": "^8.2.0",
     "helmet": "^3.21.3",
     "http-proxy-middleware": "^1.0.3",
+    "isomorphic-fetch": "^3.0.0",
     "jwt-decode": "^2.2.0",
     "launchdarkly-js-client-sdk": "^2.16.3",
     "moment-timezone": "^0.5.28",

--- a/src/browserslist
+++ b/src/browserslist
@@ -8,4 +8,4 @@
 last 2 versions
 Firefox ESR
 not dead
-not IE 9-11
+IE 9-11

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -21,6 +21,9 @@
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 import 'classlist.js';  // Run `npm install --save classlist.js`.
 
+/* IE9, IE10 and IE11 require all of the following polyfills. **/
+import 'isomorphic-fetch';  // Run `yarn add isomorphic-fetch`.
+
 /**
  * Web Animations `@angular/platform-browser/animations`
  * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6681,6 +6681,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -8412,6 +8420,11 @@ node-fetch-npm@^2.0.2:
     encoding "^0.1.11"
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -12632,6 +12645,11 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+
+whatwg-fetch@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
+  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 when@~3.6.x:
   version "3.6.4"


### PR DESCRIPTION
JIRA link: https://tools.hmcts.net/jira/browse/EUI-2746
Change Description: IE11 presents a blank screen when launching MC
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```
Resolution: IE 11 was reporting an error when trying to run the 'fetch' command. Needed to add the isomorphic-fetch module and polyfill for compatibility across different browsers.