### PR TITLE
Reset sort order when applying filter

### DIFF
--- a/src/cases/containers/case-list/case-list.component.ts
+++ b/src/cases/containers/case-list/case-list.component.ts
@@ -121,7 +121,7 @@ export class CaseListComponent implements OnInit, OnDestroy {
     this.caseListFilterEventsBindings = [
       { type: 'onApply', action: 'FindCaselistPaginationMetadata' },
       { type: 'onReset', action: 'CaseListReset' }
-     ];
+    ];
 
     this.paginationSize = this.appConfig.getPaginationPageSize();
 
@@ -443,4 +443,4 @@ export class CaseListComponent implements OnInit, OnDestroy {
       this.elasticSearchFlagSubsription.unsubscribe();
     }
   }
- }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2906


### Change description ###
Resets the sort order be reset when filtering is applied in the case list. This also required that the filter be reset on the CCD `CaseListComponent`, which necessitated a `@ViewChild()` decorator.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
