### PR TITLE
EUI-3031: Clear session storage on logout

### DIFF
--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -1,7 +1,9 @@
-import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { inject, TestBed } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
-import {Observable} from 'rxjs';
+import { Observable } from 'rxjs';
+
+import { SessionStorageService } from './../session-storage/session-storage.service';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
@@ -14,47 +16,72 @@ describe('AuthService', () => {
       ],
       providers: [
         AuthService,
+        SessionStorageService
       ]
     });
   });
 
-  it('should be created', inject([AuthService], (service: AuthService) => {
+  it('should be created', inject([AuthService],(service: AuthService) => {
     expect(service).toBeTruthy();
   }));
 
   describe('isAuthenticated', () => {
-    it('should make a call to check authentication', inject([HttpTestingController, AuthService], (httpMock: HttpTestingController, service: AuthService) => {
-      service.isAuthenticated().subscribe( response => {
-        expect(JSON.parse(String(response))).toBeFalsy();
-      });
+    it('should make a call to check authentication', inject(
+      [ HttpTestingController, AuthService ],
+      (httpMock: HttpTestingController, service: AuthService) => {
+        service.isAuthenticated().subscribe( response => {
+          expect(JSON.parse(String(response))).toBeFalsy();
+        });
 
-      const req = httpMock.expectOne('/auth/isAuthenticated');
-      expect(req.request.method).toEqual('GET');
-      req.flush('false');
-    }));
-
+        const req = httpMock.expectOne('/auth/isAuthenticated');
+        expect(req.request.method).toEqual('GET');
+        req.flush('false');
+      })
+    );
   });
 
   describe('logOut', () => {
-    it('should make a call to logOut', inject([HttpTestingController, AuthService], (httpMock: HttpTestingController, service: AuthService) => {
-      service.logOut().subscribe( response => {
-        expect(response).toBeNull();
-      });
+    it('should make a call to logOut', inject(
+      [ HttpTestingController, AuthService, SessionStorageService ],
+      (httpMock: HttpTestingController, service: AuthService, sessionStorageService: SessionStorageService) => {
+        spyOn(sessionStorageService, 'clear');
+        service.logOut().subscribe( response => {
+          expect(response).toBeNull();
+        });
 
-      const req = httpMock.expectOne('/auth/logout?noredirect=true');
-      expect(req.request.method).toEqual('GET');
-      req.flush(null);
-    }));
+        const req = httpMock.expectOne('/auth/logout?noredirect=true');
+        expect(req.request.method).toEqual('GET');
+        req.flush(null);
 
+        // Should have cleared out the session storage.
+        expect(sessionStorageService.clear).toHaveBeenCalled();
+      }
+    ));
   });
 
   describe('logOutAndRedirect', () => {
-    it('should work', inject([AuthService], async (service: AuthService) => {
-      const spyOnSetWindowLocation = spyOn(service, 'setWindowLocationHref');
-      spyOn(service, 'logOut').and.returnValue(Observable.of(false));
-      await service.logOutAndRedirect();
-      expect(spyOnSetWindowLocation).toHaveBeenCalledWith('/idle-sign-out');
-    }));
+    it('should work', inject(
+      [AuthService],
+      async (service: AuthService) => {
+        const spyOnSetWindowLocation = spyOn(service, 'setWindowLocationHref');
+        spyOn(service, 'logOut').and.returnValue(Observable.of(false));
+        service.logOutAndRedirect();
+        expect(spyOnSetWindowLocation).toHaveBeenCalledWith('/idle-sign-out');
+      }
+    ));
+  });
+
+  describe('signOut', () => {
+    it('should work', inject(
+      [AuthService, SessionStorageService],
+      async (service: AuthService, sessionStorageService: SessionStorageService) => {
+        spyOn(sessionStorageService, 'clear');
+        const spyOnSetWindowLocation = spyOn(service, 'setWindowLocationHref');
+        service.signOut();
+        expect(spyOnSetWindowLocation).toHaveBeenCalledWith('/auth/logout');
+        expect(sessionStorageService.clear).toHaveBeenCalled();
+      }
+    ));
   });
 
 });

--- a/src/app/services/auth/auth.service.spec.ts
+++ b/src/app/services/auth/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { inject, TestBed } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
-import { SessionStorageService } from './../session-storage/session-storage.service';
+import { SessionStorageService } from '../session-storage/session-storage.service';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
@@ -21,7 +21,7 @@ describe('AuthService', () => {
     });
   });
 
-  it('should be created', inject([AuthService],(service: AuthService) => {
+  it('should be created', inject([AuthService], (service: AuthService) => {
     expect(service).toBeTruthy();
   }));
 
@@ -36,8 +36,8 @@ describe('AuthService', () => {
         const req = httpMock.expectOne('/auth/isAuthenticated');
         expect(req.request.method).toEqual('GET');
         req.flush('false');
-      })
-    );
+      }
+    ));
   });
 
   describe('logOut', () => {

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { SessionStorageService } from './../session-storage/session-storage.service';
+import { SessionStorageService } from '../session-storage/session-storage.service';
 
 @Injectable()
 export class AuthService {

--- a/src/app/services/auth/auth.service.ts
+++ b/src/app/services/auth/auth.service.ts
@@ -1,13 +1,14 @@
-
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
-import {HttpClient} from '@angular/common/http';
-import {Observable} from 'rxjs';
+import { SessionStorageService } from './../session-storage/session-storage.service';
 
 @Injectable()
 export class AuthService {
   constructor(
-    private readonly httpService: HttpClient
+    private readonly httpService: HttpClient,
+    private readonly sessionStorageService: SessionStorageService
   ) {
   }
 
@@ -21,11 +22,15 @@ export class AuthService {
   }
 
   public signOut() {
+    // Clear out the SessionStorage.
+    this.sessionStorageService.clear();
     const href = '/auth/logout';
     this.setWindowLocationHref(href);
   }
 
   public logOut(): Observable<any> {
+    // Clear out the SessionStorage.
+    this.sessionStorageService.clear();
     return this.httpService.get('/auth/logout?noredirect=true');
   }
 

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -1,0 +1,5 @@
+import { SessionStorageService } from './session-storage/session-storage.service';
+
+export {
+  SessionStorageService
+};

--- a/src/app/services/session-storage/session-storage.service.ts
+++ b/src/app/services/session-storage/session-storage.service.ts
@@ -18,4 +18,11 @@ export class SessionStorageService {
   public setItem(key: string, value: string): void {
     sessionStorage.setItem(key, value);
   }
+
+  /**
+   * Clear all the items held in session storage.
+   */
+  public clear(): void {
+    sessionStorage.clear();
+  }
 }

--- a/src/work-allocation/components/available-tasks-filter/available-tasks-filter.component.ts
+++ b/src/work-allocation/components/available-tasks-filter/available-tasks-filter.component.ts
@@ -2,8 +2,9 @@ import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild }
 import { Router } from '@angular/router';
 import { CheckboxListComponent } from '@hmcts/rpx-xui-common-lib';
 
+import { SessionStorageService } from '../../../app/services';
 import { Location } from '../../models/dtos';
-import { LocationDataService, SessionStorageService } from '../../services';
+import { LocationDataService } from '../../services';
 import { handleFatalErrors, WILDCARD_SERVICE_DOWN } from '../../utils';
 import { FilterConstants } from '../constants';
 

--- a/src/work-allocation/components/task-manager-filter/task-manager-filter.component.ts
+++ b/src/work-allocation/components/task-manager-filter/task-manager-filter.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 
+import { SessionStorageService } from '../../../app/services';
 import { Caseworker, Location } from '../../models/dtos';
-import { SessionStorageService } from '../../services';
 import { FilterConstants } from '../constants';
 
 @Component({

--- a/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.ts
+++ b/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.ts
@@ -2,11 +2,12 @@ import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 
+import { SessionStorageService } from '../../../app/services';
 import { ListConstants } from '../../components/constants';
 import { InfoMessage, InfoMessageType, TaskService, TaskSort } from '../../enums';
 import { SearchTaskParameter, SearchTaskRequest } from '../../models/dtos';
 import { InvokedTaskAction, Task, TaskFieldConfig, TaskServiceConfig, TaskSortField } from '../../models/tasks';
-import { InfoMessageCommService, SessionStorageService, WorkAllocationTaskService } from '../../services';
+import { InfoMessageCommService, WorkAllocationTaskService } from '../../services';
 import { handleFatalErrors, WILDCARD_SERVICE_DOWN } from '../../utils';
 
 @Component({

--- a/src/work-allocation/containers/task-manager-list/task-manager-list.component.spec.ts
+++ b/src/work-allocation/containers/task-manager-list/task-manager-list.component.spec.ts
@@ -5,17 +5,13 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ExuiCommonLibModule } from '@hmcts/rpx-xui-common-lib';
 import { of } from 'rxjs';
 
+import { SessionStorageService } from '../../../app/services';
 import { FilterConstants } from '../../components/constants';
 import { WorkAllocationComponentsModule } from '../../components/work-allocation.components.module';
 import * as dtos from '../../models/dtos';
 import { Task } from '../../models/tasks';
 import { CaseworkerDisplayName } from '../../pipes';
-import {
-  CaseworkerDataService,
-  LocationDataService,
-  SessionStorageService,
-  WorkAllocationTaskService,
-} from '../../services';
+import { CaseworkerDataService, LocationDataService, WorkAllocationTaskService } from '../../services';
 import { getMockCaseworkers, getMockLocations, getMockTasks } from '../../tests/utils.spec';
 import { TaskListComponent } from '../task-list/task-list.component';
 import { TaskManagerListComponent } from './task-manager-list.component';

--- a/src/work-allocation/containers/task-manager-list/task-manager-list.component.ts
+++ b/src/work-allocation/containers/task-manager-list/task-manager-list.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { SessionStorageService } from '../../../app/services';
 import { ConfigConstants, FilterConstants, ListConstants, SortConstants } from '../../components/constants';
 import { TaskActionIds } from '../../enums';
 import { Caseworker, Location, SearchTaskRequest } from '../../models/dtos';
@@ -10,7 +11,6 @@ import {
   CaseworkerDataService,
   InfoMessageCommService,
   LocationDataService,
-  SessionStorageService,
   WorkAllocationTaskService,
 } from '../../services';
 import { handleFatalErrors } from '../../utils';

--- a/src/work-allocation/services/index.ts
+++ b/src/work-allocation/services/index.ts
@@ -1,13 +1,11 @@
 import { CaseworkerDataService } from './caseworker-data.service';
 import { InfoMessageCommService } from './info-message-comms.service';
 import { LocationDataService } from './location-data.service';
-import { SessionStorageService } from './session-storage.service';
 import { WorkAllocationTaskService } from './work-allocation-task.service';
 
 export {
   CaseworkerDataService,
   InfoMessageCommService,
   LocationDataService,
-  SessionStorageService,
   WorkAllocationTaskService
 };


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3031


### Change description ###
Clear the session storage whenever the user logs out (or is logged out). This is driven by the requirement to clear out the filters in the work allocation area at the end of the "session" (and not just the end of the browser session, which is how session storage technically works).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```