### PR TITLE
Fix caselist loading when not running on ES

### DIFF
--- a/api/amendedJurisdictions/index.spec.ts
+++ b/api/amendedJurisdictions/index.spec.ts
@@ -61,7 +61,7 @@ describe('Amended Jurisdiction', () => {
     sandbox.restore()
   })
 
-  it('should filter jurisdicitons for the jurisdictions endpoint',  () => {
+  it('should filter jurisdictions for the jurisdictions endpoint',  () => {
     const data = [
       {
         id: 'PROBATE',

--- a/api/amendedJurisdictions/index.spec.ts
+++ b/api/amendedJurisdictions/index.spec.ts
@@ -35,7 +35,7 @@ describe('Amended Jurisdiction', () => {
               fun()
           },
       },
-      url: 'fdafu4543543/binary',
+      url: 'aggregated/caseworkers/:uid/jurisdictions?access=read',
   })
 
     result0 = {

--- a/api/amendedJurisdictions/index.spec.ts
+++ b/api/amendedJurisdictions/index.spec.ts
@@ -35,7 +35,7 @@ describe('Amended Jurisdiction', () => {
               fun()
           },
       },
-      url: 'aggregated/caseworkers/:uid/jurisdictions?access=read',
+      url: 'fdafu4543543/binary',
   })
 
     result0 = {
@@ -61,12 +61,36 @@ describe('Amended Jurisdiction', () => {
     sandbox.restore()
   })
 
-  it('should send PROBATE array',  () => {
-    const expected = [
-        {
-            id: 'PROBATE',
-        },
+  it('should filter jurisdicitons for the jurisdictions endpoint',  () => {
+    const data = [
+      {
+        id: 'PROBATE',
+      },
+      {
+        id: 'RANDOM',
+      },
     ]
+    req.url = 'aggregated/caseworkers/:uid/jurisdictions?access=read'
+    const response = amendedJurisdictions.getJurisdictions(proxyRes, req, res, data)
+    // Unknown jurisdiction should be filtered
+    const expected = [
+      {
+        id: 'PROBATE',
+      },
+    ]
+    expect(response).to.eql(expected)
+  })
+
+  it('should not filter jurisdictions for non-jurisdictions endpoint',  () => {
+    const expected = [
+      {
+        id: 'PROBATE',
+      },
+      {
+        id: 'RANDOM',
+      },
+    ]
+    req.url = '/aggregated/some/other/url'
 
     const response = amendedJurisdictions.getJurisdictions(proxyRes, req, res, expected)
     expect(response).to.eql(expected)

--- a/api/amendedJurisdictions/index.ts
+++ b/api/amendedJurisdictions/index.ts
@@ -1,22 +1,28 @@
 import {getConfigValue} from '../configuration'
 import { JURISDICTIONS } from '../configuration/references'
 
+const jurisdictions = /aggregated\/.+jurisdictions\?/
+
 /**
  * Manually filtering returned jurisdictions
  * to make available jurisdiction in filters array only
  */
 export const getJurisdictions = (proxyRes, req, res, data: any[]) => {
-    if (!Array.isArray(data)) {
+    if (!Array.isArray(data)
+        || !jurisdictions.test(req.url)) {
         return data
     }
+
     const filters = getConfigValue(JURISDICTIONS)
     req.session.jurisdictions = [...data].filter(o => filters.includes(o.id))
     return req.session.jurisdictions
 }
 
 export const checkCachedJurisdictions = (proxyReq, req, res) => {
-    if (req.session.jurisdictions) {
-        res.send(req.session.jurisdictions)
-        proxyReq.end()
+    if (jurisdictions.test(req.url)) {
+        if (req.session.jurisdictions) {
+            res.send(req.session.jurisdictions)
+            proxyReq.end()
+        }
     }
 }

--- a/api/amendedJurisdictions/index.ts
+++ b/api/amendedJurisdictions/index.ts
@@ -12,7 +12,6 @@ export const getJurisdictions = (proxyRes, req, res, data: any[]) => {
         || !jurisdictions.test(req.url)) {
         return data
     }
-
     const filters = getConfigValue(JURISDICTIONS)
     req.session.jurisdictions = [...data].filter(o => filters.includes(o.id))
     return req.session.jurisdictions


### PR DESCRIPTION
### Change description ###

This fixes loading of the case list when not running on Elastic Search.

This change avoids returning jurisdicitonal details instead of case data.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
