### PR TITLE
EUI-3387: Menu not showing on reload for Work Allocation

### DIFF
--- a/src/app/containers/app/app.component.ts
+++ b/src/app/containers/app/app.component.ts
@@ -3,6 +3,7 @@ import { Title } from '@angular/platform-browser';
 import { Router, RoutesRecognized } from '@angular/router';
 import { GoogleAnalyticsService, TimeoutNotificationsService } from '@hmcts/rpx-xui-common-lib';
 import { select, Store } from '@ngrx/store';
+
 import { propsExist } from '../../../../api/lib/objectUtilities';
 import { environment as config } from '../../../environments/environment';
 import * as fromRoot from '../../store';
@@ -51,6 +52,12 @@ export class AppComponent implements OnInit {
         this.loadAndListenForUserDetails();
       }
     });
+
+    // Moved here from CaseHomeComponent as this needs to be app-wide, and
+    // not just happening for the Case view. Moreover, it has an impact on
+    // the rendering of the menu as it triggers an action that gets hold of
+    // the user's profile.
+    this.store.dispatch(new fromRoot.StartIdleSessionTimeout());
   }
 
   /**

--- a/src/cases/containers/case-home/case-home.component.ts
+++ b/src/cases/containers/case-home/case-home.component.ts
@@ -1,12 +1,15 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import {
   AlertService,
-  ErrorNotifierService, HttpError, NavigationNotifierService,
-  NavigationOrigin
+  ErrorNotifierService,
+  HttpError,
+  NavigationNotifierService,
+  NavigationOrigin,
 } from '@hmcts/ccd-case-ui-toolkit';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs';
 import { GoActionParams } from 'src/cases/models/go-action-params.model';
+
 import * as fromRoot from '../../../app/store';
 import * as fromFeature from '../../store';
 
@@ -42,8 +45,6 @@ export class CaseHomeComponent implements OnInit, OnDestroy {
         this.actionDispatcher(this.paramHandler(navigation));
       }
     }) as any;
-
-    this.store.dispatch(new fromRoot.StartIdleSessionTimeout());
   }
 
   public ngOnDestroy(): void {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3387


### Change description ###
`StartIdleSessionTimeout` triggers an action that gets hold of the user's profile, which is needed for rendering the menu options. This was only happening in the `CaseHomeComponent`, which means it wasn't happening on reload of anything else.

I've moved it up to the `AppComponent` in a corresponding location (at the end of `ngOnInit()`), which means it'll be across the entire app, rather than just for cases.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```