### PR TITLE
remove proxy.end() inside of activityTracker

### DIFF
--- a/api/activityTracker/index.ts
+++ b/api/activityTracker/index.ts
@@ -8,8 +8,6 @@ export async function activityTrackerProxyRequest(proxyReq, req): Promise<void> 
       `id:${req.user.userinfo.id} forename:${req.user.userinfo.forename} surname:${req.user.userinfo.surname}`
     );
   }
-
-  proxyReq.end();
 }
 
 export async function activityTrackerProxyResponse(proxyReq, req, res, json): Promise<any> {


### PR DESCRIPTION
### Change description ###
Remove proxy.end() inside of activityTracker which is causing post proxy requests to fail


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
