### PR TITLE
EUI-3664 Fix WA Task Assignee disappearing on refresh

### DIFF
--- a/src/work-allocation/components/task-assignment/task-assignment.component.ts
+++ b/src/work-allocation/components/task-assignment/task-assignment.component.ts
@@ -150,7 +150,7 @@ export class TaskAssignmentComponent implements OnInit {
   private setupCaseworkerLocation(): void {
     this.caseworkerService.getAll().subscribe(caseworkers => {
       const assignedCaseworker = caseworkers.find(cw => this.isLoggedInUser(cw.idamId));
-      this.pCaseworkerLocation = assignedCaseworker.location ? assignedCaseworker.location : null;
+      this.pCaseworkerLocation = (assignedCaseworker && assignedCaseworker.location) ? assignedCaseworker.location : null;
     }, error => {
       handleFatalErrors(error.status, this.router, WILDCARD_SERVICE_DOWN);
     });

--- a/src/work-allocation/containers/task-assignment/task-assignment-container.component.spec.ts
+++ b/src/work-allocation/containers/task-assignment/task-assignment-container.component.spec.ts
@@ -3,7 +3,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { Component, Input, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Observable } from 'rxjs';
 
@@ -18,7 +18,7 @@ import {
 import { Assignee } from '../../models/dtos';
 import { Task } from '../../models/tasks';
 import { InfoMessageCommService, WorkAllocationTaskService } from '../../services';
-import { getMockCaseworkers, getMockTasks } from '../../tests/utils.spec';
+import { getMockCaseworkers, getMockTasks, MockRouter } from '../../tests/utils.spec';
 
 @Component({
   template: `<exui-task-container-assignment></exui-task-container-assignment>`
@@ -82,7 +82,7 @@ describe('TaskAssignmentContainerComponent', () => {
     component = wrapper.appComponentRef;
 
     wrapper.tasks = null;
-    window.history.pushState({ returnUrl: 'tasks/list', showAssigneeColumn: false }, '', 'tasks/list');
+    window.history.pushState({ returnUrl: 'tasks/list' }, '', 'tasks/list');
     fixture.detectChanges();
   });
 
@@ -136,5 +136,11 @@ describe('TaskAssignmentContainerComponent', () => {
     };
     expect(mockWorkAllocationService.assignTask).toHaveBeenCalledWith(mockTasks[0].id, assignee);
   });
-  // TODO: Need to write tests regarding template
+
+  it('should show assignee column when relevant', () => {
+    const router = TestBed.get(Router);
+    spyOnProperty(router, 'url', 'get').and.returnValues(`/example-url/assign`, `/example-url/reassign`);
+    expect(component.fields.pop().name).not.toBe('assigneeName');
+    expect(component.fields.pop().name).toBe('assigneeName');
+  });
 });

--- a/src/work-allocation/containers/task-assignment/task-assignment-container.component.ts
+++ b/src/work-allocation/containers/task-assignment/task-assignment-container.component.ts
@@ -52,10 +52,9 @@ export class TaskAssignmentContainerComponent implements OnInit {
   }
 
   private get showAssigneeColumn(): boolean {
-    if (window && window.history && window.history.state) {
-      return !!window.history.state.showAssigneeColumn;
-    }
-    return false;
+    const url = this.router.url;
+    // unless action is assign, show the current assignee
+    return (url.includes('reassign') || url.includes('unassign'));
   }
 
   public taskServiceConfig: TaskServiceConfig = {

--- a/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.spec.ts
+++ b/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.spec.ts
@@ -70,7 +70,7 @@ describe('TaskListWrapperComponent', () => {
       // need to verify correct properties were called
       const lastNavigateCall = mockRouter.navigateCalls.pop();
       expect(lastNavigateCall.commands).toEqual([`/tasks/${exampleTask.id}/${firstAction.id}/`]);
-      const exampleNavigateCall = { state: { returnUrl: '/tasks/list', showAssigneeColumn: true } };
+      const exampleNavigateCall = { state: { returnUrl: '/tasks/list' } };
       expect(lastNavigateCall.extras).toEqual(exampleNavigateCall);
     });
 
@@ -86,7 +86,7 @@ describe('TaskListWrapperComponent', () => {
       // need to verify correct properties were called
       const lastNavigateCall = mockRouter.navigateCalls.pop();
       expect(lastNavigateCall.commands).toEqual([`/tasks/${exampleTask.id}/${secondAction.id}/`]);
-      const exampleNavigateCall = { state: { returnUrl: '/tasks/manager', showAssigneeColumn: true } };
+      const exampleNavigateCall = { state: { returnUrl: '/tasks/manager' } };
       expect(lastNavigateCall.extras).toEqual(exampleNavigateCall);
     });
   });

--- a/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.ts
+++ b/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.ts
@@ -199,8 +199,7 @@ export class TaskListWrapperComponent implements OnInit {
       this.specificPage = 'manager';
     }
     const state = {
-      returnUrl: this.returnUrl,
-      showAssigneeColumn: taskAction.action.id !== TaskActionIds.ASSIGN
+      returnUrl: this.returnUrl
     };
     const actionUrl = `/tasks/${taskAction.task.id}/${taskAction.action.id}/${this.specificPage}`;
     this.router.navigate([actionUrl], { state });


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3664


### Change description ###
Showing the assignee column had been set via the window.state.history with a boolean value. This fails when a refresh is used as the assignee column disappears. Therefore the assignee column is now set to appear based on which action appears in the url.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
