### PR TITLE
EUI-3756: Enable wildcard searching for HRS jurisdiction

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -67,6 +67,9 @@
       "generatedSurname",
       "appeal.appellant.name.lastName"
     ],
+    "HearingRecordings": [
+      "recordingReference"
+    ],
     "xuiTestCaseType": [
       "TextField"
     ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-3756

### Change description ###
Enable wildcard searches on the `recordingReference` field for the `HearingRecordings` Case Type.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
