### PR TITLE
work allocation, set correct search params for when assignee is set to unassigned

### DIFF
--- a/src/work-allocation/containers/task-manager-list/task-manager-list.component.spec.ts
+++ b/src/work-allocation/containers/task-manager-list/task-manager-list.component.spec.ts
@@ -182,8 +182,8 @@ describe('TaskManagerListComponent', () => {
     expect(searchRequest.search_parameters.length).toEqual(2);
     expect(searchRequest.search_parameters[0].key).toEqual('location');
     expect(searchRequest.search_parameters[0].values.length).toEqual(mockLocations.length);
-    expect(searchRequest.search_parameters[1].key).toEqual('user');
-    expect(searchRequest.search_parameters[1].values.length).toEqual(0);
+    expect(searchRequest.search_parameters[1].key).toEqual('state');
+    expect(searchRequest.search_parameters[1].values).toEqual(['unassigned']);
 
     // Let's also make sure that the tasks were re-requested with the new sorting.
     const payload = { searchRequest, view: component.view };

--- a/src/work-allocation/containers/task-manager-list/task-manager-list.component.ts
+++ b/src/work-allocation/containers/task-manager-list/task-manager-list.component.ts
@@ -163,16 +163,18 @@ export class TaskManagerListComponent extends TaskListWrapperComponent implement
   }
 
   private getCaseworkerParameter() {
+    let key: string = 'user';
     let values: string[];
     if (this.selectedCaseworker && this.selectedCaseworker !== FilterConstants.Options.Caseworkers.ALL) {
       if (this.selectedCaseworker === FilterConstants.Options.Caseworkers.UNASSIGNED) {
-        values = [];
+        key = 'state';
+        values = ['unassigned'];
       } else {
         values = [this.selectedCaseworker.idamId];
       }
     } else {
       values = [];
     }
-    return { key: 'user', operator: 'IN', values };
+    return { key: `${key}`, operator: 'IN', values };
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-4085


### Change description ###
updated unit test and search parameters should be:
key: "state",
values: ["unassigned"],
operator: "IN"
when 'none(unassigned taks)' is selected


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
