### PR TITLE
Generically name task related models / enums for reusability. Fix tests and wa2->wa1 references

### DIFF
--- a/src/work-allocation-2/components/constants/config.constants.ts
+++ b/src/work-allocation-2/components/constants/config.constants.ts
@@ -1,55 +1,55 @@
-import { TaskFieldType, TaskView } from '../../enums';
-import { TaskFieldConfig } from '../../models/tasks';
+import { FieldType, TaskView } from '../../enums';
+import { FieldConfig } from '../../models/common';
 import { DERIVED_ICON_CONSTANTS} from './derived-icon.constants';
 
 /**
  * The individual fields.
  */
-const CASE_REFERENCE_AS_LINK: TaskFieldConfig = {
+const CASE_REFERENCE_AS_LINK: FieldConfig = {
   name: 'case_id',
-  type: TaskFieldType.CASE_REFERENCE,
+  type: FieldType.CASE_REFERENCE,
   columnLabel: 'Case reference',
   sortName: 'caseId',
   views: TaskView.ALL_VIEWS
 };
-const CASE_REFERENCE_AS_TEXT: TaskFieldConfig = {
+const CASE_REFERENCE_AS_TEXT: FieldConfig = {
   name: 'case_id',
-  type: TaskFieldType.CASE_REFERENCE_STRING,
+  type: FieldType.CASE_REFERENCE_STRING,
   columnLabel: 'Case reference',
   sortName: 'caseId',
   views: TaskView.ALL_VIEWS
 };
-const CASE_NAME_AS_LINK: TaskFieldConfig = {
+const CASE_NAME_AS_LINK: FieldConfig = {
   name: 'case_name',
-  type: TaskFieldType.CASE_NAME,
+  type: FieldType.CASE_NAME,
   columnLabel: 'Case name',
   sortName: 'caseName',
   views: TaskView.ALL_VIEWS
 };
-const CASE_NAME_AS_TEXT: TaskFieldConfig = {
+const CASE_NAME_AS_TEXT: FieldConfig = {
   name: 'case_name',
-  type: TaskFieldType.STRING,
+  type: FieldType.STRING,
   columnLabel: 'Case name',
   sortName: 'caseName',
   views: TaskView.ALL_VIEWS
 };
-const CASE_CATEGORY: TaskFieldConfig = {
+const CASE_CATEGORY: FieldConfig = {
   name: 'case_category',
-  type: TaskFieldType.STRING,
+  type: FieldType.STRING,
   columnLabel: 'Case category',
   sortName: 'caseCategory',
   views: TaskView.ALL_VIEWS
 };
-const LOCATION: TaskFieldConfig = {
+const LOCATION: FieldConfig = {
   name: 'location_name',
-  type: TaskFieldType.STRING,
+  type: FieldType.STRING,
   columnLabel: 'Location',
   sortName: 'locationName',
   views: TaskView.ALL_VIEWS
 };
-const DERIVED_ICON: TaskFieldConfig = {
+const DERIVED_ICON: FieldConfig = {
   name: 'derivedIcon',
-  type: TaskFieldType.DERIVED_ICON,
+  type: FieldType.DERIVED_ICON,
   columnLabel: null,
   views: TaskView.ALL_VIEWS,
   sortName: 'derivedIcon',
@@ -57,30 +57,30 @@ const DERIVED_ICON: TaskFieldConfig = {
   sourceColumn: DERIVED_ICON_CONSTANTS.SOURCE_COLUMN,
   matchValue: DERIVED_ICON_CONSTANTS.MATCH_VALUE
 };
-const TASK_NAME_AS_LINK: TaskFieldConfig = {
+const TASK_NAME_AS_LINK: FieldConfig = {
   name: 'task_title',
-  type: TaskFieldType.TASK_NAME,
+  type: FieldType.TASK_NAME,
   columnLabel: 'Task',
   sortName: 'taskTitle',
   views: TaskView.ALL_VIEWS
 };
-const TASK_NAME_AS_TEXT: TaskFieldConfig = {
+const TASK_NAME_AS_TEXT: FieldConfig = {
   name: 'task_title',
-  type: TaskFieldType.STRING,
+  type: FieldType.STRING,
   columnLabel: 'Task',
   sortName: 'taskTitle',
   views: TaskView.ALL_VIEWS
 };
-const DUE_DATE: TaskFieldConfig = {
+const DUE_DATE: FieldConfig = {
   name: 'dueDate',
-  type: TaskFieldType.DATE_DUE,
+  type: FieldType.DATE_DUE,
   columnLabel: 'Date',
   sortName: 'dueDate',
   views: TaskView.ALL_VIEWS
 };
-const ASSIGNEE: TaskFieldConfig = {
+const ASSIGNEE: FieldConfig = {
   name: 'assigneeName',
-  type: TaskFieldType.STRING,
+  type: FieldType.STRING,
   columnLabel: 'Person',
   sortName: 'assignee',
   views: TaskView.ALL_VIEWS
@@ -90,26 +90,26 @@ const ASSIGNEE: TaskFieldConfig = {
 /**
  * The views.
  */
-const AVAILABLE_TASKS: TaskFieldConfig[] = [
+const AVAILABLE_TASKS: FieldConfig[] = [
   CASE_NAME_AS_TEXT, CASE_CATEGORY, LOCATION, DERIVED_ICON, TASK_NAME_AS_TEXT, DUE_DATE
 ];
-const MY_TASKS: TaskFieldConfig[] = [
+const MY_TASKS: FieldConfig[] = [
   CASE_REFERENCE_AS_LINK, CASE_NAME_AS_TEXT, CASE_CATEGORY, LOCATION, DERIVED_ICON, TASK_NAME_AS_TEXT, DUE_DATE
 ];
-const MY_WORK_TASKS: TaskFieldConfig[] = [
+const MY_WORK_TASKS: FieldConfig[] = [
   CASE_NAME_AS_LINK, CASE_CATEGORY, LOCATION, DERIVED_ICON, TASK_NAME_AS_LINK, DUE_DATE
 ];
-const TASK_MANAGER: TaskFieldConfig[] = [
+const TASK_MANAGER: FieldConfig[] = [
   CASE_NAME_AS_TEXT, CASE_CATEGORY, LOCATION, TASK_NAME_AS_TEXT, DUE_DATE, ASSIGNEE
 ];
-const TASK_ACTIONS: TaskFieldConfig[] = [
+const TASK_ACTIONS: FieldConfig[] = [
   ...MY_TASKS
 ];
-const TASK_ACTIONS_WITH_ASSIGNEE: TaskFieldConfig[] = [
+const TASK_ACTIONS_WITH_ASSIGNEE: FieldConfig[] = [
   ...TASK_MANAGER
 ];
 
-const ALL_WORK_TASKS: TaskFieldConfig[] = [
+const ALL_WORK_TASKS: FieldConfig[] = [
   CASE_NAME_AS_TEXT, CASE_CATEGORY, LOCATION, DERIVED_ICON, TASK_NAME_AS_TEXT, DUE_DATE, ASSIGNEE
 ]
 

--- a/src/work-allocation-2/components/task-field/task-field.component.spec.ts
+++ b/src/work-allocation-2/components/task-field/task-field.component.spec.ts
@@ -1,8 +1,9 @@
 import { Component, Input, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { TaskFieldType, TaskView } from './../../enums';
-import { Task, TaskFieldConfig } from './../../models/tasks';
+import { FieldConfig } from '../../models/common';
+import { FieldType, TaskView } from './../../enums';
+import { Task } from './../../models/tasks';
 import { WorkAllocationComponentsModule } from '../work-allocation.components.module';
 import { TaskFieldComponent } from './task-field.component';
 
@@ -11,7 +12,7 @@ import { TaskFieldComponent } from './task-field.component';
 })
 class WrapperComponent {
   @ViewChild(TaskFieldComponent) public appComponentRef: TaskFieldComponent;
-  @Input() public config: TaskFieldConfig;
+  @Input() public config: FieldConfig;
   @Input() public task: Task;
 }
 
@@ -22,7 +23,7 @@ describe('WorkAllocation', () => {
     let wrapper: WrapperComponent;
     let fixture: ComponentFixture<WrapperComponent>;
 
-    function getConfig(name: string, type: TaskFieldType): TaskFieldConfig {
+    function getConfig(name: string, type: FieldType): FieldConfig {
       return {
         name,
         type,
@@ -51,7 +52,7 @@ describe('WorkAllocation', () => {
       expect(fixture.debugElement.nativeElement.innerText).toBe('');
 
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('caseName', TaskFieldType.STRING);
+      const config: FieldConfig = getConfig('caseName', FieldType.STRING);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -81,7 +82,7 @@ describe('WorkAllocation', () => {
 
     it('should handle a STRING type', () => {
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('case_id', TaskFieldType.STRING);
+      const config: FieldConfig = getConfig('case_id', FieldType.STRING);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -115,7 +116,7 @@ describe('WorkAllocation', () => {
       expect(fixture.debugElement.nativeElement.querySelector('.due-date')).toBeNull();
 
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('dueDate', TaskFieldType.DATE_DUE);
+      const config: FieldConfig = getConfig('dueDate', FieldType.DATE_DUE);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -165,7 +166,7 @@ describe('WorkAllocation', () => {
 
     it('should handle a DATE_AGE_DAYS type', () => {
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('dueDate', TaskFieldType.DATE_AGE_DAYS);
+      const config: FieldConfig = getConfig('dueDate', FieldType.DATE_AGE_DAYS);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -211,7 +212,7 @@ describe('WorkAllocation', () => {
 
     it('should handle a DATE type', () => {
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('dueDate', TaskFieldType.DATE);
+      const config: FieldConfig = getConfig('dueDate', FieldType.DATE);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -242,7 +243,7 @@ describe('WorkAllocation', () => {
 
     it('should handle a DATETIME type', () => {
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('dueDate', TaskFieldType.DATETIME);
+      const config: FieldConfig = getConfig('dueDate', FieldType.DATETIME);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -273,7 +274,7 @@ describe('WorkAllocation', () => {
 
     it('should handle a BOOLEAN type', () => {
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('happy', TaskFieldType.BOOLEAN);
+      const config: FieldConfig = getConfig('happy', FieldType.BOOLEAN);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -347,7 +348,7 @@ describe('WorkAllocation', () => {
 
     it('should handle an INTEGER type', () => {
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('pi', TaskFieldType.INTEGER);
+      const config: FieldConfig = getConfig('pi', FieldType.INTEGER);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -411,7 +412,7 @@ describe('WorkAllocation', () => {
 
     it('should handle an DECIMAL_2 type', () => {
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('pi', TaskFieldType.DECIMAL_2);
+      const config: FieldConfig = getConfig('pi', FieldType.DECIMAL_2);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -481,7 +482,7 @@ describe('WorkAllocation', () => {
       expect(fixture.debugElement.nativeElement.querySelector('a')).toBeNull();
 
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('link', TaskFieldType.URL);
+      const config: FieldConfig = getConfig('link', FieldType.URL);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -553,7 +554,7 @@ describe('WorkAllocation', () => {
       expect(fixture.debugElement.nativeElement.querySelector('img')).toBeNull();
 
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('image', TaskFieldType.IMAGE);
+      const config: FieldConfig = getConfig('image', FieldType.IMAGE);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -622,7 +623,7 @@ describe('WorkAllocation', () => {
       expect(fixture.debugElement.nativeElement.querySelector('a')).toBeNull();
 
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('case_id', TaskFieldType.CASE_REFERENCE);
+      const config: FieldConfig = getConfig('case_id', FieldType.CASE_REFERENCE);
       const task: Task = {
         id: 'The task ID',
         case_id: 'The case reference',
@@ -675,7 +676,7 @@ describe('WorkAllocation', () => {
       expect(fixture.debugElement.nativeElement.querySelector('a')).toBeNull();
 
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('caseName', TaskFieldType.CASE_NAME);
+      const config: FieldConfig = getConfig('caseName', FieldType.CASE_NAME);
       const task: Task = {
         id: 'The task ID',
         case_id: '1',
@@ -729,7 +730,7 @@ describe('WorkAllocation', () => {
       expect(fixture.debugElement.nativeElement.querySelector('a')).toBeNull();
 
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('taskName', TaskFieldType.TASK_NAME);
+      const config: FieldConfig = getConfig('taskName', FieldType.TASK_NAME);
       const task: Task = {
         id: 'The task ID',
         case_id: '1',
@@ -780,7 +781,7 @@ describe('WorkAllocation', () => {
     it('should handle a CASE_REFERENCE_AS_STRING type', () => {
 
       // Set up the config and the task.
-      const config: TaskFieldConfig = getConfig('case_id', TaskFieldType.CASE_REFERENCE_STRING);
+      const config: FieldConfig = getConfig('case_id', FieldType.CASE_REFERENCE_STRING);
       const task: Task = {
         id: 'The task ID',
         case_id: '1234567890987654',

--- a/src/work-allocation-2/components/task-field/task-field.component.ts
+++ b/src/work-allocation-2/components/task-field/task-field.component.ts
@@ -1,8 +1,7 @@
 import { Component, Input, ViewEncapsulation } from '@angular/core';
-import { Task, TaskFieldConfig } from '.././../models/tasks';
-
-import { TaskFieldType } from './../../enums';
-
+import { FieldConfig } from '../../models/common';
+import { FieldType } from './../../enums';
+import { Task } from '.././../models/tasks';
 @Component({
   selector: 'exui-task-field',
   templateUrl: './task-field.component.html',
@@ -14,7 +13,7 @@ export class TaskFieldComponent {
    * to obtain the correct value from the task and determine how it
    * should be rendered.
    */
-  @Input() public config: TaskFieldConfig;
+  @Input() public config: FieldConfig;
 
   /**
    * The task, which contains the value we want to render in this
@@ -24,7 +23,7 @@ export class TaskFieldComponent {
 
   // This is here for the ngSwitch in the template so we don't have
   // hard-coded strings floating around the place.
-  protected fieldType = TaskFieldType;
+  protected fieldType = FieldType;
 
   /**
    * Convert a string, number, or Date to date object.

--- a/src/work-allocation-2/containers/all-work-task/all-work-task.component.ts
+++ b/src/work-allocation-2/containers/all-work-task/all-work-task.component.ts
@@ -5,11 +5,12 @@ import { UserInfo } from 'src/app/models/user-details.model';
 import { SessionStorageService } from 'src/app/services';
 import { CONFIG_CONSTANTS } from 'src/work-allocation-2/components/constants/config.constants';
 import { LIST_CONSTANTS } from 'src/work-allocation-2/components/constants/list.constants';
-import { TaskService, TaskSort } from 'src/work-allocation-2/enums';
+import { SortOrder, TaskService } from 'src/work-allocation-2/enums';
 import { PaginationParameter, SearchTaskRequest, SortParameter } from 'src/work-allocation-2/models/dtos';
 import { WorkAllocationTaskService } from 'src/work-allocation-2/services';
 import { handleFatalErrors, WILDCARD_SERVICE_DOWN } from 'src/work-allocation-2/utils';
-import { InvokedTaskAction, Task, TaskFieldConfig, TaskServiceConfig, TaskSortField } from '../../models/tasks';
+import { FieldConfig, SortField } from '../../models/common';
+import { InvokedTaskAction, Task, TaskServiceConfig } from '../../models/tasks';
 
 @Component({
     selector: 'exui-all-work-tasks',
@@ -21,9 +22,9 @@ export class AllWorkTaskComponent implements OnInit {
                      private sessionStorageService: SessionStorageService,
                      private readonly router: Router) {}
 
-  public sortedBy: TaskSortField = {
+  public sortedBy: SortField = {
     fieldName: '',
-    order: TaskSort.NONE
+    order: SortOrder.NONE
   };
 
   public pagination: PaginationParameter = {
@@ -34,14 +35,14 @@ export class AllWorkTaskComponent implements OnInit {
 
   private readonly defaultTaskServiceConfig: TaskServiceConfig = {
     service: TaskService.IAC,
-    defaultSortDirection: TaskSort.NONE,
+    defaultSortDirection: SortOrder.NONE,
     defaultSortFieldName: 'dueDate',
     fields: this.fields,
   };
   public tasks: Task[] = new Array<Task>();
   public tasksTotal: number = 0;
 
-  public get fields(): TaskFieldConfig[] {
+  public get fields(): FieldConfig[] {
     return CONFIG_CONSTANTS.AllWorkTasks;
   }
 

--- a/src/work-allocation-2/containers/available-tasks/available-tasks.component.ts
+++ b/src/work-allocation-2/containers/available-tasks/available-tasks.component.ts
@@ -2,12 +2,12 @@ import { Component } from '@angular/core';
 import { InvokedTaskAction, Task } from '../../..//work-allocation-2/models/tasks';
 import { InfoMessage, InfoMessageType, TaskActionIds } from '../../../work-allocation-2/enums';
 import { SearchTaskRequest } from '../../../work-allocation-2/models/dtos';
-import { TaskFieldConfig } from '../../../work-allocation-2/models/tasks';
 import { handleFatalErrors, REDIRECTS } from '../../../work-allocation-2/utils';
 
 import { UserInfo } from '../../../app/models/user-details.model';
 import { ConfigConstants, ListConstants, PageConstants, SortConstants } from '../../components/constants';
 import { TaskListWrapperComponent } from '../task-list-wrapper/task-list-wrapper.component';
+import { FieldConfig } from '../../models/common';
 
 @Component({
   selector: 'exui-available-tasks',
@@ -15,7 +15,7 @@ import { TaskListWrapperComponent } from '../task-list-wrapper/task-list-wrapper
 })
 export class AvailableTasksComponent extends TaskListWrapperComponent {
 
-  public get fields(): TaskFieldConfig[] {
+  public get fields(): FieldConfig[] {
     return ConfigConstants.AvailableTasks;
   }
 

--- a/src/work-allocation-2/containers/my-tasks/my-tasks.component.spec.ts
+++ b/src/work-allocation-2/containers/my-tasks/my-tasks.component.spec.ts
@@ -9,7 +9,7 @@ import { of } from 'rxjs';
 import { SessionStorageService } from 'src/app/services';
 import { TaskListComponent } from '..';
 import { WorkAllocationComponentsModule } from '../../components/work-allocation.components.module';
-import { TaskFieldType } from '../../enums';
+import { FieldType } from '../../enums';
 import { Task } from '../../models/tasks';
 import { CaseworkerDataService, WorkAllocationFeatureService, WorkAllocationTaskService } from '../../services';
 import { getMockTasks } from '../../tests/utils.spec';
@@ -147,7 +147,7 @@ describe('MyTasksComponent', () => {
     component.ngOnInit();
     fixture.detectChanges();
     expect(component.fields[0].name).toBe('case_name');
-    expect(component.fields[0].type).toBe(TaskFieldType.CASE_NAME);
-    expect(component.fields[4].type).toBe(TaskFieldType.TASK_NAME);
+    expect(component.fields[0].type).toBe(FieldType.CASE_NAME);
+    expect(component.fields[4].type).toBe(FieldType.TASK_NAME);
   });
 });

--- a/src/work-allocation-2/containers/my-tasks/my-tasks.component.ts
+++ b/src/work-allocation-2/containers/my-tasks/my-tasks.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
 import { UserInfo } from '../../../app/models/user-details.model';
 import { ConfigConstants, ListConstants, PageConstants, SortConstants } from '../../components/constants';
+import { FieldConfig } from '../../models/common';
 import { SearchTaskRequest } from '../../models/dtos';
-import { TaskFieldConfig } from '../../models/tasks';
 import { TaskListWrapperComponent } from '../task-list-wrapper/task-list-wrapper.component';
 
 @Component({
@@ -27,7 +27,7 @@ export class MyTasksComponent extends TaskListWrapperComponent {
     return ListConstants.View.MyTasks;
   }
 
-  public get fields(): TaskFieldConfig[] {
+  public get fields(): FieldConfig[] {
     return ConfigConstants.MyWorkTasks;
   }
 

--- a/src/work-allocation-2/containers/task-action/task-action-container.component.ts
+++ b/src/work-allocation-2/containers/task-action/task-action-container.component.ts
@@ -2,9 +2,10 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ConfigConstants } from '../../components/constants';
-import { InfoMessage, InfoMessageType, TaskActionType, TaskService, TaskSort } from '../../enums';
+import { InfoMessage, InfoMessageType, SortOrder, TaskActionType, TaskService } from '../../enums';
+import { FieldConfig } from '../../models/common';
 import { InformationMessage } from '../../models/comms';
-import { TaskFieldConfig, TaskServiceConfig } from '../../models/tasks';
+import { TaskServiceConfig } from '../../models/tasks';
 import { InfoMessageCommService, WorkAllocationTaskService } from '../../services';
 import { ACTION } from '../../services/work-allocation-task.service';
 import { handleFatalErrors } from '../../utils';
@@ -34,7 +35,7 @@ export class TaskActionContainerComponent implements OnInit {
     private readonly messageService: InfoMessageCommService
   ) {}
 
-  public get fields(): TaskFieldConfig[] {
+  public get fields(): FieldConfig[] {
     return ConfigConstants.TaskActionsWithAssignee;
   }
 
@@ -48,7 +49,7 @@ export class TaskActionContainerComponent implements OnInit {
 
   public taskServiceConfig: TaskServiceConfig = {
     service: TaskService.IAC,
-    defaultSortDirection: TaskSort.ASC,
+    defaultSortDirection: SortOrder.ASC,
     defaultSortFieldName: 'dueDate',
     fields: this.fields,
   };

--- a/src/work-allocation-2/containers/task-assignment/task-assignment-container.component.ts
+++ b/src/work-allocation-2/containers/task-assignment/task-assignment-container.component.ts
@@ -5,10 +5,11 @@ import { Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ErrorMessage } from '../../../app/models';
 import { ConfigConstants } from '../../components/constants';
-import { TaskActionType, TaskService, TaskSort } from '../../enums';
+import { SortOrder, TaskActionType, TaskService } from '../../enums';
+import { FieldConfig } from '../../models/common';
 import { InformationMessage } from '../../models/comms';
 import { Caseworker, Location, Person } from '../../models/dtos';
-import { TaskFieldConfig, TaskServiceConfig } from '../../models/tasks';
+import { TaskServiceConfig } from '../../models/tasks';
 import { InfoMessageCommService, WorkAllocationTaskService } from '../../services';
 
 @Component({
@@ -39,7 +40,7 @@ export class TaskAssignmentContainerComponent implements OnInit, OnDestroy {
     private readonly messageService: InfoMessageCommService
   ) { }
 
-  public get fields(): TaskFieldConfig[] {
+  public get fields(): FieldConfig[] {
     return this.showAssigneeColumn ? ConfigConstants.TaskActionsWithAssignee : ConfigConstants.TaskActions;
   }
 
@@ -62,7 +63,7 @@ export class TaskAssignmentContainerComponent implements OnInit, OnDestroy {
 
   public taskServiceConfig: TaskServiceConfig = {
     service: TaskService.IAC,
-    defaultSortDirection: TaskSort.ASC,
+    defaultSortDirection: SortOrder.ASC,
     defaultSortFieldName: 'dueDate',
     fields: this.fields,
   };

--- a/src/work-allocation-2/containers/task-home/task-home.component.ts
+++ b/src/work-allocation-2/containers/task-home/task-home.component.ts
@@ -5,7 +5,7 @@ import { Subscription } from 'rxjs';
 
 import { AppUtils } from '../../../app/app-utils';
 import { ErrorMessage } from '../../../app/models';
-import { TaskSortField } from '../../models/tasks';
+import { SortField } from '../../models/common';
 
 @Component({
   selector: 'exui-task-home',
@@ -13,7 +13,7 @@ import { TaskSortField } from '../../models/tasks';
   styleUrls: ['task-home.component.scss']
 })
 export class TaskHomeComponent implements OnInit, OnDestroy {
-  public sortedBy: TaskSortField;
+  public sortedBy: SortField;
   public pageTitle: string;
   public error: ErrorMessage = null;
   public jurisdiction: string = 'Immigration & Asylum';

--- a/src/work-allocation-2/containers/task-list-wrapper/task-list-wrapper.component.ts
+++ b/src/work-allocation-2/containers/task-list-wrapper/task-list-wrapper.component.ts
@@ -7,9 +7,10 @@ import { Caseworker } from 'api/workAllocation/interfaces/task';
 import { Observable } from 'rxjs';
 import { SessionStorageService } from '../../../app/services';
 import { ListConstants } from '../../components/constants';
-import { InfoMessage, InfoMessageType, TaskActionIds, TaskService, TaskSort } from '../../enums';
+import { InfoMessage, InfoMessageType, SortOrder, TaskActionIds, TaskService } from '../../enums';
+import { FieldConfig, SortField } from '../../models/common';
 import { PaginationParameter, SearchTaskRequest, SortParameter } from '../../models/dtos';
-import { InvokedTaskAction, Task, TaskFieldConfig, TaskServiceConfig, TaskSortField } from '../../models/tasks';
+import { InvokedTaskAction, Task, TaskServiceConfig } from '../../models/tasks';
 import { CaseworkerDataService, InfoMessageCommService, WorkAllocationTaskService } from '../../services';
 import { getAssigneeName, handleFatalErrors, WILDCARD_SERVICE_DOWN } from '../../utils';
 
@@ -22,7 +23,7 @@ export class TaskListWrapperComponent implements OnInit {
   public specificPage: string = '';
   public caseworkers: Caseworker[];
   public showSpinner$: Observable<boolean>;
-  public sortedBy: TaskSortField;
+  public sortedBy: SortField;
   public pagination: PaginationParameter;
   private pTasks: Task[];
   /**
@@ -30,7 +31,7 @@ export class TaskListWrapperComponent implements OnInit {
    */
   private readonly defaultTaskServiceConfig: TaskServiceConfig = {
     service: TaskService.IAC,
-    defaultSortDirection: TaskSort.ASC,
+    defaultSortDirection: SortOrder.ASC,
     defaultSortFieldName: 'dueDate',
     fields: this.fields,
   };
@@ -67,7 +68,7 @@ export class TaskListWrapperComponent implements OnInit {
     this.pTasksTotal = value;
   }
 
-  public get fields(): TaskFieldConfig[] {
+  public get fields(): FieldConfig[] {
     return [];
   }
 
@@ -133,7 +134,7 @@ export class TaskListWrapperComponent implements OnInit {
       const { fieldName, order } = JSON.parse(sortStored);
       this.sortedBy = {
         fieldName,
-        order: order as TaskSort
+        order: order as SortOrder
       };
     } else {
       // Otherwise, set up the default sorting.
@@ -214,9 +215,9 @@ export class TaskListWrapperComponent implements OnInit {
    * @param fieldName - ie. 'caseName'
    */
   public onSortHandler(fieldName: string): void {
-    let order: TaskSort = TaskSort.ASC;
-    if (this.sortedBy.fieldName === fieldName && this.sortedBy.order === TaskSort.ASC) {
-      order = TaskSort.DSC;
+    let order: SortOrder = SortOrder.ASC;
+    if (this.sortedBy.fieldName === fieldName && this.sortedBy.order === SortOrder.ASC) {
+      order = SortOrder.DESC;
     }
     this.sortedBy = { fieldName, order };
     this.sessionStorageService.setItem(this.sortSessionKey, JSON.stringify(this.sortedBy));

--- a/src/work-allocation-2/containers/task-list/task-list.component.spec.ts
+++ b/src/work-allocation-2/containers/task-list/task-list.component.spec.ts
@@ -7,13 +7,14 @@ import { FeatureToggleService } from '@hmcts/rpx-xui-common-lib';
 import { of } from 'rxjs';
 import { PaginationParameter } from 'src/work-allocation-2/models/dtos';
 
-import { ConfigConstants } from '../../../work-allocation/components/constants';
-import { WorkAllocationComponentsModule } from '../../components/work-allocation.components.module';
-import { TaskService, TaskSort } from '../../../work-allocation/enums';
-import { Task, TaskAction, TaskFieldConfig, TaskServiceConfig, TaskSortField } from '../../../work-allocation/models/tasks';
-import { WorkAllocationTaskService } from '../../../work-allocation/services';
-import { getMockTasks, MockRouter } from '../../../work-allocation/tests/utils.spec';
+import { Task, TaskAction, TaskServiceConfig } from '../../../work-allocation-2/models/tasks';
 import { TaskListComponent } from './task-list.component';
+import { SortOrder, TaskService } from '../../enums';
+import { FieldConfig, SortField } from '../../models/common';
+import { ConfigConstants } from '../../components/constants';
+import { getMockTasks, MockRouter } from '../../tests/utils.spec';
+import { WorkAllocationComponentsModule } from '../../components/work-allocation.components.module';
+import { WorkAllocationTaskService } from '../../services';
 
 @Component({
   template: `
@@ -22,17 +23,17 @@ import { TaskListComponent } from './task-list.component';
       [tasks]='tasks'
       [tasksTotal]="tasksTotal"
       [taskServiceConfig]="taskServiceConfig"
-      [sortedBy]="TaskSortField"
+      [sortedBy]="SortField"
       [pagination]="pagination"></exui-task-list>`
 })
 class WrapperComponent {
   @ViewChild(TaskListComponent) public appComponentRef: TaskListComponent;
-  @Input() public fields: TaskFieldConfig[];
+  @Input() public fields: FieldConfig[];
   @Input() public tasks: Task[];
   @Input() public tasksTotal: number;
   @Input() public taskServiceConfig: TaskServiceConfig;
   @Input() public pagination: PaginationParameter;
-  @Input() public sortedBy: TaskSortField;
+  @Input() public sortedBy: SortField;
 }
 
 /**
@@ -45,7 +46,7 @@ function getTasks(): Task[] {
 /**
  * Mock fields
  */
-function getFields(): TaskFieldConfig[] {
+function getFields(): FieldConfig[] {
   return ConfigConstants.AvailableTasks;
 }
 
@@ -55,7 +56,7 @@ function getFields(): TaskFieldConfig[] {
 function getTaskService(): TaskServiceConfig {
   return {
     service: TaskService.IAC,
-    defaultSortDirection: TaskSort.ASC,
+    defaultSortDirection: SortOrder.ASC,
     defaultSortFieldName: 'dueDate',
     fields: getFields(),
   };
@@ -115,12 +116,12 @@ describe('TaskListComponent', () => {
   it('should return the columns to be displayed by the Angular Component Dev Kit table.', async () => {
 
     // create mock getDisplayedColumn variables
-    const taskFieldConfig = getFields();
-    const fields = taskFieldConfig.map(field => field.name);
+    const fieldConfig = getFields();
+    const fields = fieldConfig.map(field => field.name);
     const displayedColumns = component.addManageColumn(fields);
 
     // test actual function against mock variables
-    expect(component.getDisplayedColumn(taskFieldConfig)).toEqual(displayedColumns);
+    expect(component.getDisplayedColumn(fieldConfig)).toEqual(displayedColumns);
 
   });
 
@@ -129,13 +130,13 @@ describe('TaskListComponent', () => {
     // mock the emitter and dispatch the connected event
     spyOn(component.sortEvent, 'emit');
     const element = fixture.debugElement.nativeElement;
-    const button = element.querySelector('#sort_by_caseId');
+    const button = element.querySelector('#sort_by_caseName');
     button.dispatchEvent(new Event('click'));
     fixture.detectChanges();
 
-    // check the emitter had been called and that it gets called with the first field which is caseReference (caseId)
+    // check the emitter had been called and that it gets called with the first field which is caseName
     expect(component.sortEvent.emit).toHaveBeenCalled();
-    expect(component.sortEvent.emit).toHaveBeenCalledWith('caseId');
+    expect(component.sortEvent.emit).toHaveBeenCalledWith('caseName');
   });
 
   it('reset sort button is hidden by default', async () => {
@@ -149,10 +150,10 @@ describe('TaskListComponent', () => {
     const element = fixture.debugElement.nativeElement;
     const button = element.querySelector('#sort_by_caseName');
     button.dispatchEvent(new Event('click'));
-    component.sortedBy = { fieldName: 'caseName', order: TaskSort.DSC };
+    component.sortedBy = { fieldName: 'caseName', order: SortOrder.DESC };
     fixture.detectChanges();
 
-    // check the emitter had been called and that it gets called with the new field defined which is taskName
+    // check the emitter had been called and that it gets called with the new field defined which is caseName
     expect(component.sortEvent.emit).toHaveBeenCalled();
     expect(component.sortEvent.emit).toHaveBeenCalledWith('caseName');
 
@@ -385,7 +386,7 @@ describe('TaskListComponent', () => {
     // mock the emitter and dispatch the connected event (with example case field buttons selected)
     spyOn(component.sortEvent, 'emit');
     const element = fixture.debugElement.nativeElement;
-    const referenceButton = element.querySelector('#sort_by_caseId');
+    const referenceButton = element.querySelector('#sort_by_caseName');
     const categoryButton = element.querySelector('#sort_by_caseCategory');
     const dueDateButton = element.querySelector('#sort_by_dueDate');
     referenceButton.dispatchEvent(new Event('click'));
@@ -393,13 +394,13 @@ describe('TaskListComponent', () => {
 
     // check the case reference is being sorted via ascending
     expect(component.sortEvent.emit).toHaveBeenCalled();
-    expect(component.sortEvent.emit).toHaveBeenCalledWith('caseId');
+    expect(component.sortEvent.emit).toHaveBeenCalledWith('caseName');
 
     // check that the case reference is being sorted via descending
     referenceButton.dispatchEvent(new Event('click'));
     fixture.detectChanges();
     expect(component.sortEvent.emit).toHaveBeenCalled();
-    expect(component.sortEvent.emit).toHaveBeenCalledWith('caseId');
+    expect(component.sortEvent.emit).toHaveBeenCalledWith('caseName');
 
     // click the second example button and verify that sorting is for case category
     categoryButton.dispatchEvent(new Event('click'));

--- a/src/work-allocation-2/containers/task-list/task-list.component.ts
+++ b/src/work-allocation-2/containers/task-list/task-list.component.ts
@@ -4,8 +4,9 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { PaginationParameter } from '../..//models/dtos';
 
 import { ListConstants } from '../../components/constants';
-import { TaskSort } from '../../enums';
-import { InvokedTaskAction, Task, TaskAction, TaskFieldConfig, TaskServiceConfig, TaskSortField } from '../../models/tasks';
+import { SortOrder } from '../../enums';
+import { FieldConfig, SortField } from '../../models/common';
+import { InvokedTaskAction, Task, TaskAction, TaskServiceConfig } from '../../models/tasks';
 
 @Component({
   selector: 'exui-task-list',
@@ -20,7 +21,7 @@ export class TaskListComponent implements OnChanges {
   @Input() public tasks: Task[];
   @Input() public tasksTotal: number;
   @Input() public taskServiceConfig: TaskServiceConfig;
-  @Input() public sortedBy: TaskSortField;
+  @Input() public sortedBy: SortField;
   @Input() public addActionsColumn: boolean = true;
   @Input() public pagination: PaginationParameter;
   @Input() public showManage = {};
@@ -32,7 +33,7 @@ export class TaskListComponent implements OnChanges {
 
   // TODO: Need to re-read the LLD, but I believe it says pass in the taskServiceConfig into this TaskListComponent.
   // Therefore we will not need this.
-  @Input() public fields: TaskFieldConfig[];
+  @Input() public fields: FieldConfig[];
 
   @Output() public sortEvent = new EventEmitter<string>();
   @Output() public paginationEvent = new EventEmitter<number>();
@@ -90,8 +91,8 @@ export class TaskListComponent implements OnChanges {
    * Returns the columns to be displayed by the Angular Component Dev Kit table.
    *
    */
-  public getDisplayedColumn(taskFieldConfig: TaskFieldConfig[]): string[] {
-    const fields = taskFieldConfig.map(field => field.name);
+  public getDisplayedColumn(fieldConfig: FieldConfig[]): string[] {
+    const fields = fieldConfig.map(field => field.name);
     return this.addActionsColumn ? this.addManageColumn(fields) : fields;
   }
 
@@ -179,11 +180,11 @@ export class TaskListComponent implements OnChanges {
 
     // If this is the field we're sorted by, return the appropriate order.
     if (this.sortedBy.fieldName === fieldName) {
-      return this.sortedBy.order === TaskSort.ASC ? 'ascending' : 'descending';
+      return this.sortedBy.order === SortOrder.ASC ? 'ascending' : 'descending';
     }
 
     // This field is not sorted, return NONE.
-    return TaskSort.NONE;
+    return SortOrder.NONE;
   }
 
   public onResetSorting(): void {

--- a/src/work-allocation-2/containers/task-manager-list/task-manager-list.component.ts
+++ b/src/work-allocation-2/containers/task-manager-list/task-manager-list.component.ts
@@ -5,8 +5,8 @@ import { FeatureToggleService } from '@hmcts/rpx-xui-common-lib';
 
 import { SessionStorageService } from '../../../app/services';
 import { ConfigConstants, FilterConstants, ListConstants, SortConstants } from '../../components/constants';
+import { FieldConfig } from '../../models/common';
 import { Caseworker, Location, SearchTaskRequest } from '../../models/dtos';
-import { TaskFieldConfig } from '../../models/tasks';
 import {
   CaseworkerDataService,
   InfoMessageCommService,
@@ -43,7 +43,7 @@ export class TaskManagerListComponent extends TaskListWrapperComponent implement
     super(ref, taskService, router, infoMessageCommService, sessionStorageService, alertService, caseworkerService, loadingService, featureToggleService);
   }
 
-  public get fields(): TaskFieldConfig[] {
+  public get fields(): FieldConfig[] {
     return ConfigConstants.TaskManager;
   }
 

--- a/src/work-allocation-2/enums/field-type.ts
+++ b/src/work-allocation-2/enums/field-type.ts
@@ -1,4 +1,4 @@
-export enum TaskFieldType {
+export enum FieldType {
   STRING,
   DATE_DUE,              // Display as fancy colour coded date
   DATE_AGE_DAYS,         // Display as number of days since date

--- a/src/work-allocation-2/enums/index.ts
+++ b/src/work-allocation-2/enums/index.ts
@@ -1,19 +1,19 @@
 import { InfoMessage } from './info-message';
 import { InfoMessageType } from './info-message-type';
+import { SortOrder } from './sort-order';
 import { TaskActionIds } from './task-action-ids';
 import { TaskActionType } from './task-action-type';
-import { TaskFieldType } from './task-field-type';
+import { FieldType } from './field-type';
 import { TaskService } from './task-service';
-import { TaskSort } from './task-sort';
 import { TaskView } from './task-view';
 
 export {
+  FieldType,
   InfoMessage,
   InfoMessageType,
+  SortOrder,
   TaskActionIds,
   TaskActionType,
-  TaskFieldType,
   TaskService,
-  TaskSort,
   TaskView
 };

--- a/src/work-allocation-2/enums/sort-order.ts
+++ b/src/work-allocation-2/enums/sort-order.ts
@@ -1,0 +1,5 @@
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+  NONE = 'none'
+}

--- a/src/work-allocation-2/enums/task-sort.ts
+++ b/src/work-allocation-2/enums/task-sort.ts
@@ -1,5 +1,0 @@
-export enum TaskSort {
-  ASC = 'asc',
-  DSC = 'desc',
-  NONE = 'none'
-}

--- a/src/work-allocation-2/models/common/field-config.model.ts
+++ b/src/work-allocation-2/models/common/field-config.model.ts
@@ -1,8 +1,8 @@
-import { TaskFieldType } from './../../enums';
+import { FieldType } from './../../enums';
 
-export default interface TaskFieldConfig {
+export default interface FieldConfig {
   name: string;          // as returned by task api
-  type: TaskFieldType;
+  type: FieldType;
   columnLabel: string;   // can be null for no column header
   views: number;         // bitwise or of the TaskViews that this field is to appear in
   sortName?: string;     // for the purpose of sorting (data names not 100% matching)

--- a/src/work-allocation-2/models/common/index.ts
+++ b/src/work-allocation-2/models/common/index.ts
@@ -1,0 +1,7 @@
+import FieldConfig from './field-config.model';
+import SortField from './sort-field.model';
+
+export {
+  FieldConfig,
+  SortField
+};

--- a/src/work-allocation-2/models/common/sort-field.model.ts
+++ b/src/work-allocation-2/models/common/sort-field.model.ts
@@ -1,0 +1,6 @@
+import { SortOrder } from './../../enums';
+
+export default interface SortField {
+  fieldName: string;
+  order: SortOrder;
+}

--- a/src/work-allocation-2/models/tasks/index.ts
+++ b/src/work-allocation-2/models/tasks/index.ts
@@ -1,15 +1,11 @@
 import InvokedTaskAction from './invoked-task-action.model';
 import TaskAction from './task-action.model';
-import TaskFieldConfig from './task-field-config.model';
 import TaskServiceConfig from './task-service-config.model';
-import TaskSortField from './task-sort-field.model';
 import Task from './task.model';
 
 export {
   InvokedTaskAction,
   Task,
   TaskAction,
-  TaskFieldConfig,
-  TaskServiceConfig,
-  TaskSortField
+  TaskServiceConfig
 };

--- a/src/work-allocation-2/models/tasks/task-service-config.model.ts
+++ b/src/work-allocation-2/models/tasks/task-service-config.model.ts
@@ -1,9 +1,9 @@
-import { TaskFieldConfig } from '.';
-import { TaskService, TaskSort } from './../../enums';
+import { FieldConfig } from '../common';
+import { SortOrder, TaskService } from './../../enums';
 
 export default interface TaskServiceConfig {
   service: TaskService;
-  defaultSortDirection: TaskSort;
+  defaultSortDirection: SortOrder;
   defaultSortFieldName: string;
-  fields: TaskFieldConfig[];
+  fields: FieldConfig[];
 }

--- a/src/work-allocation-2/models/tasks/task-sort-field.model.ts
+++ b/src/work-allocation-2/models/tasks/task-sort-field.model.ts
@@ -1,6 +1,0 @@
-import { TaskSort } from './../../enums';
-
-export default interface TaskSortField {
-  fieldName: string;
-  order: TaskSort;
-}

--- a/src/work-allocation-2/tests/utils.spec.ts
+++ b/src/work-allocation-2/tests/utils.spec.ts
@@ -1,9 +1,10 @@
 import { NavigationExtras } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { ConfigConstants } from '../components/constants';
-import { TaskService, TaskSort } from '../enums';
+import { SortOrder, TaskService } from '../enums';
+import { FieldConfig } from '../models/common';
 import { Caseworker, Location } from '../models/dtos';
-import { Task, TaskFieldConfig, TaskServiceConfig } from '../models/tasks';
+import { Task, TaskServiceConfig } from '../models/tasks';
 
 const LOCATION_A: Location = { id: 'a', locationName: 'Taylor House', services: [ 'a' ] };
 const LOCATION_B: Location = { id: 'b', locationName: 'Taylor Swift', services: [ 'a', 'b' ] };
@@ -77,7 +78,7 @@ export function getMockTasks(): Task[] {
 /**
  * Mock fields
  */
-export function getMockTaskFieldConfig(): TaskFieldConfig[] {
+export function getMockTaskFieldConfig(): FieldConfig[] {
   return ConfigConstants.AvailableTasks;
 }
 
@@ -87,7 +88,7 @@ export function getMockTaskFieldConfig(): TaskFieldConfig[] {
 export function getMockTaskServiceConfig(): TaskServiceConfig {
   return {
     service: TaskService.IAC,
-    defaultSortDirection: TaskSort.ASC,
+    defaultSortDirection: SortOrder.ASC,
     defaultSortFieldName: 'dueDate',
     fields: getMockTaskFieldConfig()
   };

--- a/src/work-allocation/containers/task-list/task-list.component.spec.ts
+++ b/src/work-allocation/containers/task-list/task-list.component.spec.ts
@@ -126,13 +126,13 @@ describe('TaskListComponent', () => {
     // mock the emitter and dispatch the connected event
     spyOn(component.sortEvent, 'emit');
     const element = fixture.debugElement.nativeElement;
-    const button = element.querySelector('#sort_by_caseId');
+    const button = element.querySelector('#sort_by_caseName');
     button.dispatchEvent(new Event('click'));
     fixture.detectChanges();
 
-    // check the emitter had been called and that it gets called with the first field which is caseReference (caseId)
+    // check the emitter had been called and that it gets called with the first field which is caseName
     expect(component.sortEvent.emit).toHaveBeenCalled();
-    expect(component.sortEvent.emit).toHaveBeenCalledWith('caseId');
+    expect(component.sortEvent.emit).toHaveBeenCalledWith('caseName');
   });
 
   it('should allow sorting for different columns.', async () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a


### Change description ###
Renamed the following enums and models and updated references in all affected files:
- task-field-type.ts -> field-type.ts (enum)
- task-sort.ts -> sort-order.ts (enum)
- task-field-config.model.ts -> field-config.model.ts
- task-sort-field.model.ts -> sort-field.model.ts

Also fixed two failing tests (the same file in wa/wa2), and updated references that were pointing to files in wa from wa2

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
