### PR TITLE
Reset Search column based config fix

### DIFF
--- a/src/work-allocation-2/components/constants/config.constants.ts
+++ b/src/work-allocation-2/components/constants/config.constants.ts
@@ -123,6 +123,7 @@ const DUE_DATE: FieldConfig = {
   views: TaskView.ALL_VIEWS
 };
 const DUE_DATE_AS_TEXT: FieldConfig = {
+  isDate: false,
   name: 'dueDate',
   type: FieldType.FORMATTED_DATE,
   columnLabel: 'Due date',
@@ -130,6 +131,7 @@ const DUE_DATE_AS_TEXT: FieldConfig = {
   views: TaskView.ALL_VIEWS
 };
 const CREATED_DATE: FieldConfig = {
+  isDate: true,
   name: 'created_date',
   type: FieldType.FORMATTED_DATE,
   columnLabel: 'Task created',

--- a/src/work-allocation-2/containers/task-list-wrapper/task-list-wrapper.component.ts
+++ b/src/work-allocation-2/containers/task-list-wrapper/task-list-wrapper.component.ts
@@ -35,15 +35,6 @@ export class TaskListWrapperComponent implements OnDestroy, OnInit {
   protected userDetailsKey: string = 'userDetails';
 
   private selectedLocationsSubscription: Subscription;
-  /**
-   * Mock TaskServiceConfig.
-   */
-  private readonly defaultTaskServiceConfig: TaskServiceConfig = {
-    service: TaskService.IAC,
-    defaultSortDirection: SortOrder.ASC,
-    defaultSortFieldName: 'dueDate',
-    fields: this.fields,
-  };
 
   /**
    * Take in the Router so we can navigate when actions are clicked.
@@ -62,6 +53,7 @@ export class TaskListWrapperComponent implements OnDestroy, OnInit {
     protected filterService: FilterService
   ) {
   }
+  public taskServiceConfig: TaskServiceConfig;
 
   public get tasks(): Task[] {
     return this.pTasks;
@@ -83,8 +75,21 @@ export class TaskListWrapperComponent implements OnDestroy, OnInit {
     return [];
   }
 
-  public get taskServiceConfig(): TaskServiceConfig {
-    return this.defaultTaskServiceConfig;
+  public getTaskServiceConfig(): TaskServiceConfig {
+    return {
+      service: TaskService.IAC,
+      defaultSortDirection: SortOrder.ASC,
+      defaultSortFieldName: this.getDateField('dueDate'),
+      fields: this.fields
+    };
+  }
+
+  public getDateField(defaultSortColumn: string): string {
+    const field = this.fields.find(currentField => currentField.isDate);
+    if (field) {
+      return field.sortName;
+    }
+    return defaultSortColumn;
   }
 
   public get emptyMessage(): string {
@@ -129,6 +134,7 @@ export class TaskListWrapperComponent implements OnDestroy, OnInit {
   }
 
   public ngOnInit(): void {
+    this.taskServiceConfig = this.getTaskServiceConfig();
     this.loadCaseWorkersAndLocations();
     this.setupTaskList();
     this.loadTasks();

--- a/src/work-allocation-2/models/common/field-config.model.ts
+++ b/src/work-allocation-2/models/common/field-config.model.ts
@@ -9,4 +9,5 @@ export default interface FieldConfig {
   sortName?: string;     // for the purpose of sorting (data names not 100% matching)
   sourceColumn?: string; // column to be matched with
   matchValue?: any;      // value to be matched with
+  isDate?: boolean;
 }

--- a/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.spec.ts
+++ b/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.spec.ts
@@ -165,7 +165,7 @@ describe('TaskListWrapperComponent searchWithPagination', () => {
     router = TestBed.get(Router);
     component = fixture.componentInstance;
     const tasks: Task[] = [];
-    for (let i = 0; i < 25; i++){
+    for (let i = 0; i < 25; i++) {
       tasks.push(getMockTasks()[0]);
     }
     mockWorkAllocationService.searchTaskWithPagination.and.returnValue(of({ tasks, total_records: 500 }));


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-4491

### Change description ###

User type based Column configuration has broken the reset sort functionality. Fix for the Reset Sort button based on the user type.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
