### PR TITLE
EUI 4366 pagination control displays even if no records

### DIFF
--- a/src/work-allocation-2/containers/task-list/task-list.component.html
+++ b/src/work-allocation-2/containers/task-list/task-list.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="paginationEnabled" class="pagination-top"
+<div *ngIf="isPaginationEnabled()" class="pagination-top"
      attr.aria-label="{{ tasksTotal }} results have been found" role="status">
   <span class="text-16" data-test="search-result-summary__text">Showing
       <span class="govuk-!-font-weight-bold">{{ getFirstResult() }}</span>
@@ -106,4 +106,7 @@
 
 </table>
 
-<ccd-pagination [autoHide]="true" (pageChange)="paginationEvent.emit($event)" *ngIf="paginationEnabled"></ccd-pagination>
+<ccd-pagination 
+  [autoHide]="true" 
+  (pageChange)="paginationEvent.emit($event)" 
+  *ngIf="isPaginationEnabled()"></ccd-pagination>

--- a/src/work-allocation-2/containers/task-list/task-list.component.spec.ts
+++ b/src/work-allocation-2/containers/task-list/task-list.component.spec.ts
@@ -457,6 +457,18 @@ describe('TaskListComponent', () => {
     });
   });
 
+  describe('pagination display state', () => {
+    it('should display pagination', async() => {
+      component.tasks = getTasks();
+      expect(component.isPaginationEnabled()).toEqual(true);
+    });
+
+    it('should not display pagination', async() => {
+      component.tasks = [];
+      expect(component.isPaginationEnabled()).toEqual(false);
+    });
+  });
+
   describe('generate pagination summary', () => {
     let paginationSummary: HTMLElement;
 

--- a/src/work-allocation-2/containers/task-list/task-list.component.spec.ts
+++ b/src/work-allocation-2/containers/task-list/task-list.component.spec.ts
@@ -458,12 +458,12 @@ describe('TaskListComponent', () => {
   });
 
   describe('pagination display state', () => {
-    it('should display pagination', async() => {
+    it('should display pagination', async () => {
       component.tasks = getTasks();
       expect(component.isPaginationEnabled()).toEqual(true);
     });
 
-    it('should not display pagination', async() => {
+    it('should not display pagination', async () => {
       component.tasks = [];
       expect(component.isPaginationEnabled()).toEqual(false);
     });

--- a/src/work-allocation-2/containers/task-list/task-list.component.ts
+++ b/src/work-allocation-2/containers/task-list/task-list.component.ts
@@ -7,15 +7,14 @@ import { ListConstants } from '../../components/constants';
 import { SortOrder } from '../../enums';
 import { FieldConfig, SortField } from '../../models/common';
 import { InvokedTaskAction, Task, TaskAction, TaskServiceConfig } from '../../models/tasks';
+import { isDefined } from '@angular/compiler/src/util';
 
 @Component({
   selector: 'exui-task-list',
   templateUrl: './task-list.component.html',
   styleUrls: ['task-list.component.scss']
 })
-export class TaskListComponent implements OnChanges, OnInit {
-    public paginationEnabled: boolean = true;
-
+export class TaskListComponent implements OnChanges {
   /**
    * These are the tasks & fields as returned from the WA Api.
    */
@@ -51,10 +50,6 @@ export class TaskListComponent implements OnChanges, OnInit {
   private selectedTask: Task;
 
   constructor(private readonly router: Router) {
-  }
-
-  public ngOnInit(): void {
-    this.paginationEnabled = this.pagination && this.enablePagination;
   }
 
   public get showResetSortButton(): boolean {
@@ -204,6 +199,13 @@ export class TaskListComponent implements OnChanges, OnInit {
 
   public getLastResult(): number {
     return ((this.getCurrentPageIndex() * this.pagination.page_size) + this.getCurrentTaskCount());
+  }
+
+  public isPaginationEnabled(): boolean {
+    return this.pagination &&
+      this.enablePagination &&
+      isDefined(this.tasks) &&
+      this.tasks.length > 0;
   }
 
   private setDefaultSort(): void {

--- a/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.spec.ts
+++ b/src/work-allocation/containers/task-list-wrapper/task-list-wrapper.component.spec.ts
@@ -165,7 +165,7 @@ describe('TaskListWrapperComponent searchWithPagination', () => {
     router = TestBed.get(Router);
     component = fixture.componentInstance;
     const tasks: Task[] = [];
-    for (let i = 0; i < 25; i++){
+    for (let i = 0; i < 25; i++) {
       tasks.push(getMockTasks()[0]);
     }
     mockWorkAllocationService.searchTaskWithPagination.and.returnValue(of({ tasks, total_records: 500 }));


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-4366

### Change description ###
Work allocation tables displaying pagination control with 0 total items

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
