### PR TITLE
roleType Filter to avoid duplicates

### DIFF
--- a/api/workAllocation/caseWorkerService.ts
+++ b/api/workAllocation/caseWorkerService.ts
@@ -5,7 +5,7 @@ import { EnhancedRequest, JUILogger } from '../lib/models';
 import { setHeaders } from '../lib/proxy';
 
 const logger: JUILogger = log4jui.getLogger('caseworker-service');
-const MAX_RECORDS: number = 100;
+const MAX_RECORDS: number = 500;
 
 export async function handleCaseWorkerGetAll(path: string, req: EnhancedRequest): Promise<any> {
   logger.info('getting all caseworkers for', path);

--- a/api/workAllocation/util.ts
+++ b/api/workAllocation/util.ts
@@ -135,6 +135,7 @@ export function prepareRoleApiRequest(locationId?: number): any {
   const payload = {
     attributes,
     roleName: ['tribunal-caseworker', 'senior-tribunal-caseworker'],
+    roleType: ['ORGANISATION'],
     validAt: Date.UTC,
   };
   if (locationId) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-4745

### Change description ###

Change the query on retrieving caseworkers to only get roleType Organisation. This will also fix the duplicate issue we seen on PROD. Thanks

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
