### PR TITLE
fix for the loading caseworkers from role-access tab

### DIFF
--- a/src/cases/containers/roles-and-access-container/roles-and-access-container.component.ts
+++ b/src/cases/containers/roles-and-access-container/roles-and-access-container.component.ts
@@ -3,11 +3,13 @@ import { ActivatedRoute } from '@angular/router';
 import { CaseView } from '@hmcts/ccd-case-ui-toolkit';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
+import { CaseworkerDataService } from '../../../work-allocation-2/services';
 import { UserDetails } from '../../../app/models/user-details.model';
 import * as fromRoot from '../../../app/store';
 import { CaseRole, RoleExclusion } from '../../../role-access/models';
 import { RoleExclusionsService } from '../../../role-access/services';
 import { AllocateRoleService } from '../../../role-access/services';
+import { first } from 'rxjs/operators';
 
 @Component({
   selector: 'exui-roles-and-access-container',
@@ -24,7 +26,8 @@ export class RolesAndAccessContainerComponent implements OnInit {
   constructor(private readonly route: ActivatedRoute,
               private readonly store: Store<fromRoot.State>,
               private readonly roleExclusionsService: RoleExclusionsService,
-              private readonly allocateService: AllocateRoleService) {}
+              private readonly allocateService: AllocateRoleService,
+              private readonly caseworkerDataService: CaseworkerDataService) {}
 
   public ngOnInit(): void {
     this.caseDetails = this.route.snapshot.data.case as CaseView;
@@ -32,6 +35,11 @@ export class RolesAndAccessContainerComponent implements OnInit {
     const jurisdiction = this.caseDetails.metadataFields.find(field => field.id === this.jurisdictionFieldId);
     this.roles$ = this.allocateService.getCaseRoles(this.caseDetails.case_id, jurisdiction.value, this.caseDetails.case_type.id);
     this.exclusions$ = this.roleExclusionsService.getCurrentUserRoleExclusions(this.caseDetails.case_id, jurisdiction.value, this.caseDetails.case_type.id);
+
+    // We need this call. No active subscribers are needed
+    // as this will enable the loading caseworkers if not
+    // present in session storage
+    this.caseworkerDataService.getAll().pipe(first()).subscribe();
   }
 
   public applyJurisdiction(caseDetails: CaseView): void {

--- a/src/role-access/role-access.module.ts
+++ b/src/role-access/role-access.module.ts
@@ -15,6 +15,7 @@ import * as fromContainers from './containers';
 import { roleAccessRouting } from './role-access.routes';
 import { RoleExclusionsService } from './services';
 import { effects, reducers } from './store';
+import { CaseworkerDataService } from '../work-allocation-2/services';
 
 @NgModule({
   imports: [
@@ -32,10 +33,11 @@ import { effects, reducers } from './store';
   entryComponents: [],
   providers: [{
     provide: AbstractAppConfig,
-    useExisting: AppConfig,
+    useExisting: AppConfig
   },
     InfoMessageCommService,
-    RoleExclusionsService
+    RoleExclusionsService,
+    CaseworkerDataService
   ]
 })
 /**

--- a/test/nodeMock/workAllocation/reqResMapping.js
+++ b/test/nodeMock/workAllocation/reqResMapping.js
@@ -72,6 +72,9 @@ module.exports = {
         },
         '/workallocation2/judicialworker' : (req,res) => {
             res.send(workAllocationMockData.getJudicialList(20));
+        },
+        '/api/wa-supported-jurisdiction/get': (req,res) => {
+            res.send(['IA']);
         }
     },
     post: {


### PR DESCRIPTION
### Change description ###

Fix for loading the caseworkers when going directly to role-access tab

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
