### PR TITLE
EUI-4549: Case Reference search box input validation

### DIFF
--- a/src/search/utils/search-validators.spec.ts
+++ b/src/search/utils/search-validators.spec.ts
@@ -9,20 +9,20 @@ describe('SearchValidators', () => {
     control = new FormControl({});
   });
 
-  it('should fail caseReference validation if input is less than 16 digits after removing non-digits', () => {
-    control.setValue('1234 1234-1234x123-');
+  it('should fail caseReference validation if input is less than 16 digits after removing separators', () => {
+    control.setValue('1234 12-- -34-1234  123-');
     const caseReferenceValidator = SearchValidators.caseReferenceValidator();
     expect(caseReferenceValidator(control)).toEqual({caseReference: true});
   });
 
-  it('should fail caseReference validation if input is more than 16 digits after removing non-digits', () => {
-    control.setValue('1234 1234-1234x12345');
+  it('should fail caseReference validation if input is more than 16 digits after removing separators', () => {
+    control.setValue('1234 12-- -34-1234  12345');
     const caseReferenceValidator = SearchValidators.caseReferenceValidator();
     expect(caseReferenceValidator(control)).toEqual({caseReference: true});
   });
 
-  it('should pass caseReference validation if input is exactly 16 digits after removing non-digits', () => {
-    control.setValue('1234 1234-1234x1234-');
+  it('should pass caseReference validation if input is exactly 16 digits after removing separators', () => {
+    control.setValue('1234 12-- -34-1234  1234-');
     const caseReferenceValidator = SearchValidators.caseReferenceValidator();
     expect(caseReferenceValidator(control)).toBeNull();
   });
@@ -35,6 +35,18 @@ describe('SearchValidators', () => {
 
   it('should fail caseReference validation if input is the empty string', () => {
     control.setValue('');
+    const caseReferenceValidator = SearchValidators.caseReferenceValidator();
+    expect(caseReferenceValidator(control)).toEqual({caseReference: true});
+  });
+
+  it('should fail caseReference validation if input contains one or more letters', () => {
+    control.setValue('1234-1234 1234123A');
+    const caseReferenceValidator = SearchValidators.caseReferenceValidator();
+    expect(caseReferenceValidator(control)).toEqual({caseReference: true});
+  });
+
+  it('should fail caseReference validation if input contains one or more symbols (except for "-")', () => {
+    control.setValue('1234-1234 1234_1234');
     const caseReferenceValidator = SearchValidators.caseReferenceValidator();
     expect(caseReferenceValidator(control)).toEqual({caseReference: true});
   });

--- a/src/search/utils/search-validators.ts
+++ b/src/search/utils/search-validators.ts
@@ -9,13 +9,14 @@ import { SearchFormControl, SearchFormErrorType } from '../enums';
 export class SearchValidators {
 
   /**
-   * Validates case reference entry. It accepts exactly 16 digits only and excludes all non-digit characters.
+   * Validates case reference entry. Excluding spaces and '-' characters, it accepts exactly 16 digits only. All other characters are
+   * invalid.
    * @returns `ValidationErrors` object if validation fails; `null` if it passes
    */
   public static caseReferenceValidator(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
       // Use template literal to coerce control.value to a string in case it is null
-      if (!(`${control.value}`).replace(/[\D]/g, '').match(/^\d{16}$/)) {
+      if (!(`${control.value}`).replace(/[\s-]/g, '').match(/^\d{16}$/)) {
         return { caseReference: true };
       }
       return null;


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-4549](https://tools.hmcts.net/jira/browse/EUI-4549) (Scenario 5)

### Change description ###
Tighten validation so it fails if the 16-digit search box input contains any non-numeric characters (except space and `-` as separators), instead of stripping them from the input.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
