### PR TITLE
Available task permission changes

### DIFF
--- a/api/workAllocation2/constants/actions.ts
+++ b/api/workAllocation2/constants/actions.ts
@@ -70,7 +70,7 @@ export const VIEW_PERMISSIONS_ACTIONS_MATRIX = {
     Manage: [ASSIGN, GO],
   },
   AvailableTasks: {
-    Manage: [CLAIM, CLAIM_AND_GO],
+    Execute: [CLAIM, CLAIM_AND_GO],
   },
   MyCases: {
     Manage: [REASSIGN, RELEASE, GO],

--- a/api/workAllocation2/utils.spec.ts
+++ b/api/workAllocation2/utils.spec.ts
@@ -551,9 +551,9 @@ describe('workAllocation.utils', () => {
 
     it('should get correct actions for available tasks for certain permissions', () => {
       expect(getActionsByPermissions('AvailableTasks', [TaskPermission.CANCEL, TaskPermission.MANAGE]))
-        .to.deep.equal([CLAIM, CLAIM_AND_GO]);
-      expect(getActionsByPermissions('AvailableTasks', [TaskPermission.EXECUTE])).to.deep.equal([]);
-      expect(getActionsByPermissions('AvailableTasks', [TaskPermission.MANAGE, TaskPermission.CANCEL]))
+        .to.deep.equal([]);
+      expect(getActionsByPermissions('AvailableTasks', [TaskPermission.EXECUTE])).to.deep.equal([CLAIM, CLAIM_AND_GO]);
+      expect(getActionsByPermissions('AvailableTasks', [TaskPermission.MANAGE, TaskPermission.EXECUTE, TaskPermission.CANCEL]))
         .to.deep.equal([CLAIM, CLAIM_AND_GO]);
     });
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-5090


### Change description ###
Available task actions now only able to be performed via Execute/Own permissions (previously Manage)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
