### PR TITLE
my tasks actions/permissions now to case tasks

### DIFF
--- a/api/workAllocation2/index.ts
+++ b/api/workAllocation2/index.ts
@@ -24,10 +24,10 @@ import {
   handlePostRoleAssignments,
   handlePostSearch
 } from './caseWorkerService';
+import { ViewType } from './constants/actions';
 import { PaginationParameter } from './interfaces/caseSearchParameter';
 import { CaseworkerPayload, ServiceCaseworkerData } from './interfaces/caseworkerPayload';
 import { Caseworker, CaseworkersByService } from './interfaces/common';
-import { TaskList } from './interfaces/task';
 import { SearchTaskParameter } from './interfaces/taskSearchParameter';
 import { checkIfCaseAllocator } from './roleService';
 import * as roleServiceMock from './roleService.mock';
@@ -195,7 +195,9 @@ export async function getTasksByCaseId(req: EnhancedRequest, res: Response, next
   };
   try {
     const { status, data } = await handleTaskSearch(`${basePath}`, searchRequest, req);
-    return res.send(data.tasks as TaskList).status(status);
+    const currentUser = req.body.currentUser ? req.body.currentUser : '';
+    const actionedTasks = assignActionsToTasks(data.tasks, ViewType.MY_TASKS, currentUser);
+    return res.send(actionedTasks).status(status);
   } catch (e) {
     next(e);
   }

--- a/src/cases/components/case-task/case-task.component.ts
+++ b/src/cases/components/case-task/case-task.component.ts
@@ -143,10 +143,13 @@ export class CaseTaskComponent implements OnInit {
     }
 
     if (this.isTaskAssignedToCurrentUser(task)) {
-      return [
-        {id: 'reassign', text: 'Reassign task'},
-        {id: 'unclaim', text: 'Unassign task'}
-      ];
+      const taskActions = [];
+      if (task.actions.find(action => action.id === 'reassign')) {
+        taskActions.push({id: 'reassign', text: 'Reassign task'});
+      }
+      if (task.actions.find(action => action.id === 'unclaim')) {
+        taskActions.push({id: 'unclaim', text: 'Unassign task'});
+      }
     } else {
       if (permissions.includes(TaskPermission.EXECUTE) && permissions.includes(TaskPermission.MANAGE)) {
         return [


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-5217

### Change description ###

My Tasks actions on the permissions should be brought into Case Tasks [Only when task is assigned to current user]

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
