### PR TITLE
additional facilities section alignment in the summary screen

### DIFF
--- a/src/hearings/converters/additional-facilities.answer.converter.spec.ts
+++ b/src/hearings/converters/additional-facilities.answer.converter.spec.ts
@@ -33,7 +33,7 @@ describe('AdditionalFacilitiesAnswerConverter', () => {
   it('should transform additional facilities', () => {
     const STATE: State = initialState.hearings;
     const result$ = converter.transformAnswer(of(STATE));
-    const additionalFacilities = 'Immigration detention centre, In camera court';
+    const additionalFacilities = '<ul><li>Immigration detention centre</li><li>In camera court</li></ul>';
     const expected = cold('(b|)', {b: additionalFacilities});
     expect(result$).toBeObservable(expected);
   });

--- a/src/hearings/converters/additional-facilities.answer.converter.ts
+++ b/src/hearings/converters/additional-facilities.answer.converter.ts
@@ -17,11 +17,12 @@ export class AdditionalFacilitiesAnswerConverter implements AnswerConverter {
   public transformAnswer(hearingState$: Observable<State>): Observable<string> {
     return hearingState$.pipe(
       map(state => {
+        let result = '<ul>';
         const facilities = this.route.snapshot.data.additionFacilitiesOptions;
-        const selection = state.hearingRequest.hearingRequestMainModel.hearingDetails.facilitiesRequired
-          .map((facility: string) => AdditionalFacilitiesAnswerConverter.getFacilityValue(facilities, facility));
-
-        return selection.join(', ');
+        state.hearingRequest.hearingRequestMainModel.hearingDetails.facilitiesRequired
+          .map((facility: string) => result += `<li>${AdditionalFacilitiesAnswerConverter.getFacilityValue(facilities, facility)}</li>`);
+          result += '</ul>';
+        return result
       })
     );
   }

--- a/src/hearings/converters/additional-facilities.answer.converter.ts
+++ b/src/hearings/converters/additional-facilities.answer.converter.ts
@@ -20,8 +20,8 @@ export class AdditionalFacilitiesAnswerConverter implements AnswerConverter {
         let result = '<ul>';
         const facilities = this.route.snapshot.data.additionFacilitiesOptions;
         state.hearingRequest.hearingRequestMainModel.hearingDetails.facilitiesRequired
-          .map((facility: string) => result += `<li>${AdditionalFacilitiesAnswerConverter.getFacilityValue(facilities, facility)}</li>`);
-          result += '</ul>';
+        .map((facility: string) => result += `<li>${AdditionalFacilitiesAnswerConverter.getFacilityValue(facilities, facility)}</li>`);
+        result += '</ul>';
         return result
       })
     );


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-5309


### Change description ###
Display each selected additional facility in the new line wrapper instead of comma delimited in the summary screen


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
