### PR TITLE
EUI-6352

### DIFF
--- a/src/cases/containers/case-hearings/case-hearings.component.spec.ts
+++ b/src/cases/containers/case-hearings/case-hearings.component.spec.ts
@@ -339,6 +339,10 @@ describe('CaseHearingsComponent', () => {
       hearingList: {
         hearingListMainModel: HEARINGS_LIST
       },
+      hearingValues: {
+        serviceHearingValuesModel: null,
+        lastError: null
+      }
     }
   };
 

--- a/src/hearings/containers/hearing-actuals/hearing-actual-add-edit-summary/hearing-actual-add-edit-summary.component.ts
+++ b/src/hearings/containers/hearing-actuals/hearing-actual-add-edit-summary/hearing-actual-add-edit-summary.component.ts
@@ -3,8 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
 import * as moment from 'moment';
 import { Observable, Subscription } from 'rxjs';
-import { filter, first } from 'rxjs/operators';
-import { ActualHearingsUtils } from '../../../../hearings/utils/actual-hearings.utils';
+import { filter } from 'rxjs/operators';
 import { HttpError } from '../../../../models/httpError.model';
 import {
   ActualDayPartyModel,
@@ -19,6 +18,7 @@ import { ACTION, HearingActualAddEditSummaryEnum, HearingResult } from '../../..
 import { LovRefDataModel } from '../../../models/lovRefData.model';
 import { HearingsService } from '../../../services/hearings.service';
 import * as fromHearingStore from '../../../store';
+import { ActualHearingsUtils } from '../../../utils/actual-hearings.utils';
 
 @Component({
   selector: 'exui-hearing-actual-add-edit-summary',
@@ -142,6 +142,7 @@ export class HearingActualAddEditSummaryComponent implements OnInit, OnDestroy {
     return hearingActualsMainModel.hearingActuals && hearingActualsMainModel.hearingActuals.actualHearingDays && hearingActualsMainModel.hearingActuals.actualHearingDays.length > 0
       ? true : false;
   }
+
   private isHearingActualsPartiesAvailable(hearingActualsMainModel: HearingActualsMainModel) {
     return hearingActualsMainModel.hearingActuals && hearingActualsMainModel.hearingActuals.actualHearingDays && hearingActualsMainModel.hearingActuals.actualHearingDays.length > 0 &&
       hearingActualsMainModel.hearingActuals.actualHearingDays && hearingActualsMainModel.hearingActuals.actualHearingDays[0].actualDayParties &&

--- a/src/hearings/containers/hearing-actuals/hearing-actuals-view-edit-parties/hearing-actuals-view-edit-parties.component.ts
+++ b/src/hearings/containers/hearing-actuals/hearing-actuals-view-edit-parties/hearing-actuals-view-edit-parties.component.ts
@@ -3,16 +3,12 @@ import { AbstractControl, FormArray, FormBuilder, FormGroup, Validators } from '
 import { ValidationErrors } from '@angular/forms/src/directives/validators';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import * as moment from 'moment';
 import { combineLatest, Subscription } from 'rxjs';
 import { filter, first } from 'rxjs/operators';
-import { ActualHearingsUtils } from '../../../../hearings/utils/actual-hearings.utils';
 import {
   ActualDayPartyModel,
-  ActualHearingDayModel,
   HearingActualsMainModel,
   PlannedDayPartyModel,
-  PlannedHearingDayModel
 } from '../../../models/hearingActualsMainModel';
 import { HearingActualsStateData } from '../../../models/hearingActualsStateData.model';
 import { HearingChannelEnum } from '../../../models/hearings.enum';

--- a/src/hearings/resolvers/ref-data-resolver.resolve.ts
+++ b/src/hearings/resolvers/ref-data-resolver.resolve.ts
@@ -47,8 +47,8 @@ export class RefDataResolver extends ServiceIdResolverResolve implements Resolve
     }
     return this.lovRefDataService.getListOfValues(category, serviceId, isChildRequired).pipe(
       tap((lovData) => {
-        // by pass EntityRoleCode and not put it in session storage as it causes inconsistency between request/actual hearing
-        if (category !== HearingCategory.EntityRoleCode) {
+        // by pass EntityRoleCode/HearingChannel and not put them in session storage as it causes inconsistency between request/actual hearing
+        if (category !== HearingCategory.EntityRoleCode && category !== HearingCategory.HearingChannel) {
           this.sessionStorageService.setItem(sessionKey, JSON.stringify(lovData));
         }
       }),

--- a/src/hearings/store/effects/hearing-values.effects.spec.ts
+++ b/src/hearings/store/effects/hearing-values.effects.spec.ts
@@ -168,16 +168,16 @@ describe('Hearing Values Effects', () => {
       const action$ = HearingValuesEffects.handleError({
         status: 500,
         message: 'error'
-      });
-      action$.subscribe(action => expect(action).toEqual(new Go({path: ['/hearings/error']})));
+      }, '1111222233334444');
+      action$.subscribe(action => expect(action).toEqual(new Go({path: ['/cases/case-details/1111222233334444/hearings']})));
     });
 
     it('should handle 4xx related errors', () => {
       const action$ = HearingValuesEffects.handleError({
         status: 403,
         message: 'error'
-      });
-      action$.subscribe(action => expect(action).toEqual(new Go({path: ['/hearings/error']})));
+      }, '1111222233334444');
+      action$.subscribe(action => expect(action).toEqual(new Go({path: ['/cases/case-details/1111222233334444/hearings']})));
     });
   });
 });

--- a/src/hearings/store/effects/hearing-values.effects.ts
+++ b/src/hearings/store/effects/hearing-values.effects.ts
@@ -33,15 +33,15 @@ export class HearingValuesEffects {
           (response) => new hearingValuesActions.LoadHearingValuesSuccess(response)),
         catchError(error => {
           this.hearingStore.dispatch(new hearingValuesActions.LoadHearingValuesFailure(error));
-          return HearingValuesEffects.handleError(error);
+          return HearingValuesEffects.handleError(error, payload);
         })
       );
     })
   );
 
-  public static handleError(error: HttpError): Observable<Action> {
+  public static handleError(error: HttpError, caseId: string): Observable<Action> {
     if (error && error.status) {
-      return of(new fromAppStoreActions.Go({path: ['/hearings/error']}));
+      return of(new fromAppStoreActions.Go({path: [`/cases/case-details/${caseId}/hearings`]}));
     }
   }
 }

--- a/src/hearings/store/reducers/hearing-values.reducer.ts
+++ b/src/hearings/store/reducers/hearing-values.reducer.ts
@@ -17,7 +17,8 @@ export function hearingValuesReducer(currentState = initialHearingValuesState,
     case fromActions.LOAD_HEARING_VALUES_SUCCESS: {
       return {
         ...currentState,
-        serviceHearingValuesModel: action.payload
+        serviceHearingValuesModel: action.payload,
+        lastError: null
       };
     }
     case fromActions.LOAD_HEARING_VALUES_FAILURE: {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-6352


### Change description ###
When serviceHearingValues api failed it should stay on the hearing tab, rather than redirect to the hearing generic error page.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
