### PR TITLE
EUI-6468 - Display full_name instead of known_as

### DIFF
--- a/src/work-allocation-2/containers/all-work-case/all-work-case.component.spec.ts
+++ b/src/work-allocation-2/containers/all-work-case/all-work-case.component.spec.ts
@@ -118,7 +118,7 @@ describe('AllWorkCaseComponent', () => {
   it('should show judicial names when available', () => {
     const firstMockCase = component.cases[0];
     const secondMockCase = component.cases[1];
-    
+
     expect(firstMockCase.assignee).not.toBe(undefined);
     expect(firstMockCase.actorName).toBe('Mr Test');
 

--- a/src/work-allocation-2/containers/all-work-case/all-work-case.component.spec.ts
+++ b/src/work-allocation-2/containers/all-work-case/all-work-case.component.spec.ts
@@ -118,9 +118,9 @@ describe('AllWorkCaseComponent', () => {
   it('should show judicial names when available', () => {
     const firstMockCase = component.cases[0];
     const secondMockCase = component.cases[1];
-
+    
     expect(firstMockCase.assignee).not.toBe(undefined);
-    expect(firstMockCase.actorName).toBe('Test');
+    expect(firstMockCase.actorName).toBe('Mr Test');
 
     expect(secondMockCase.assignee).toBe(undefined);
     expect(secondMockCase.actorName).toBe(null);

--- a/src/work-allocation-2/containers/all-work-task/all-work-task.component.spec.ts
+++ b/src/work-allocation-2/containers/all-work-task/all-work-task.component.spec.ts
@@ -163,10 +163,10 @@ describe('AllWorkTaskComponent', () => {
     expect(searchRequest.search_parameters).not.toContain({key: 'person', operator: 'IN', values: []});
     expect(searchRequest.search_parameters).toContain({key: 'role_category', operator: 'IN', values: ['JUDICIAL']});
     // expect(searchRequest.search_parameters).toContain({key: 'priority', operator: 'IN', values: ['High']});
-  })
+  });
 
   it('should show judicial names when available', () => {
-    const firstMockTask= component.tasks[0];
+    const firstMockTask = component.tasks[0];
     const secondMockTask = component.tasks[1];
 
     expect(firstMockTask.assignee).not.toBe(undefined);

--- a/src/work-allocation-2/containers/all-work-task/all-work-task.component.spec.ts
+++ b/src/work-allocation-2/containers/all-work-task/all-work-task.component.spec.ts
@@ -15,9 +15,10 @@ import { WorkAllocationComponentsModule } from '../../components/work-allocation
 import { FieldConfig } from '../../models/common';
 import { Task } from '../../models/tasks';
 import { CaseworkerDataService, LocationDataService, WASupportedJurisdictionsService, WorkAllocationFeatureService, WorkAllocationTaskService } from '../../services';
-import { getMockTasks } from '../../tests/utils.spec';
+import { getMockCaseRoles, getMockTasks } from '../../tests/utils.spec';
 import { AllWorkTaskComponent } from './all-work-task.component';
 import { AllocateRoleService } from 'src/role-access/services';
+import { CaseRoleDetails } from 'src/role-access/models';
 
 @Component({
   template: `
@@ -90,8 +91,9 @@ describe('AllWorkTaskComponent', () => {
     component = wrapper.appComponentRef;
     router = TestBed.get(Router);
     const tasks: Task[] = getMockTasks();
+    const caseRoles: CaseRoleDetails[] = getMockCaseRoles();
     mockTaskService.searchTask.and.returnValue(of({tasks}));
-    mockRoleService.getCaseRolesUserDetails.and.returnValue(of(tasks));
+    mockRoleService.getCaseRolesUserDetails.and.returnValue(of(caseRoles));
     mockCaseworkerService.getAll.and.returnValue(of([]));
     mockFeatureService.getActiveWAFeature.and.returnValue(of('WorkAllocationRelease2'));
     mockFeatureToggleService.isEnabled.and.returnValue(of(false));
@@ -162,6 +164,17 @@ describe('AllWorkTaskComponent', () => {
     expect(searchRequest.search_parameters).toContain({key: 'role_category', operator: 'IN', values: ['JUDICIAL']});
     // expect(searchRequest.search_parameters).toContain({key: 'priority', operator: 'IN', values: ['High']});
   })
+
+  it('should show judicial names when available', () => {
+    const firstMockTask= component.tasks[0];
+    const secondMockTask = component.tasks[1];
+
+    expect(firstMockTask.assignee).not.toBe(undefined);
+    expect(firstMockTask.assigneeName).toBe('Mr Test');
+
+    expect(secondMockTask.assignee).toBe(null);
+    expect(secondMockTask.assigneeName).toBe('Sir Testing');
+  });
 
   afterEach(() => {
     fixture.destroy();

--- a/src/work-allocation-2/containers/task-list-wrapper/task-list-wrapper.component.ts
+++ b/src/work-allocation-2/containers/task-list-wrapper/task-list-wrapper.component.ts
@@ -342,7 +342,7 @@ export class TaskListWrapperComponent implements OnDestroy, OnInit {
       return this.rolesService.getCaseRolesUserDetails(assignedJudicialUsers, this.selectedServices).pipe(switchMap(((judicialUserData) => {
         result.tasks.map(task => {
           const judicialAssignedData = judicialUserData.find(judicialUser => judicialUser.sidam_id === task.assignee);
-          task.assigneeName = judicialAssignedData ? judicialAssignedData.known_as : task.assigneeName;
+          task.assigneeName = judicialAssignedData ? judicialAssignedData.full_name : task.assigneeName;
         });
         return of(result);
       })));

--- a/src/work-allocation-2/containers/work-case-list-wrapper/work-case-list-wrapper.component.ts
+++ b/src/work-allocation-2/containers/work-case-list-wrapper/work-case-list-wrapper.component.ts
@@ -313,7 +313,7 @@ export class WorkCaseListWrapperComponent implements OnInit {
             const currentCase = judicialCase;
             const theJUser = judicialUserData.find(judicialUser => judicialUser.sidam_id === judicialCase.assignee);
             if (theJUser) {
-              currentCase.actorName = theJUser.known_as;
+              currentCase.actorName = theJUser.full_name;
               return currentCase;
             }
             return currentCase;

--- a/src/work-allocation-2/tests/utils.spec.ts
+++ b/src/work-allocation-2/tests/utils.spec.ts
@@ -115,7 +115,7 @@ export function getMockCases(): Case[] {
 export function getMockTasks(): Task[] {
   return [
     {
-      assignee: null,
+      assignee: '123456789',
       assigneeName: null,
       id: '1549476532065586',
       jurisdiction: 'IA',


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-6468

### Change description ###
Display full_name instead of known_as in All work - Task and Case tab


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
