### PR TITLE
EUI-6442: default sort is hearing_date

### DIFF
--- a/src/work-allocation-2/containers/work-case-list-wrapper/work-case-list-wrapper.component.ts
+++ b/src/work-allocation-2/containers/work-case-list-wrapper/work-case-list-wrapper.component.ts
@@ -53,7 +53,7 @@ export class WorkCaseListWrapperComponent implements OnInit, OnDestroy {
   private readonly defaultCaseServiceConfig: CaseServiceConfig = {
     service: CaseService.IAC,
     defaultSortDirection: SortOrder.ASC,
-    defaultSortFieldName: 'startDate',
+    defaultSortFieldName: 'hearing_date',
     fields: this.fields,
   };
   private pCasesTotal: number;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EUI-6442 

### Change description ###

Default sort is hearing_date

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
