### PR TITLE
EUI-7354: Case Flags v2 - Filter out "Inactive" and "Not approved" flags from selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@angular/platform-browser-dynamic": "^11.2.14",
     "@angular/router": "^11.2.14",
     "@edium/fsm": "^2.1.2",
-    "@hmcts/ccd-case-ui-toolkit": "6.10.7-case-flags-manage-case-flags-ui-amendments",
+    "@hmcts/ccd-case-ui-toolkit": "6.10.7-manage-case-flags-filter-out-inactive-and-not-approved",
     "@hmcts/ccpay-web-component": "5.0.10-beta14",
     "@hmcts/frontend": "0.0.39-alpha",
     "@hmcts/media-viewer": "2.7.18-RC.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,10 +1467,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hmcts/ccd-case-ui-toolkit@6.10.7-case-flags-manage-case-flags-ui-amendments":
-  version "6.10.7-case-flags-manage-case-flags-ui-amendments"
-  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-6.10.7-case-flags-manage-case-flags-ui-amendments.tgz#3afe49d232a47a15b79341423f09f87ca76dd444"
-  integrity sha512-BLjsNugxVq//evKh9LvjOj55/z1FK44lHklMDQ7ago9etm+EnXAPM/vkmKmy4GXRXzkX0J/Krag1s+oHCXsFfQ==
+"@hmcts/ccd-case-ui-toolkit@6.10.7-manage-case-flags-filter-out-inactive-and-not-approved":
+  version "6.10.7-manage-case-flags-filter-out-inactive-and-not-approved"
+  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-6.10.7-manage-case-flags-filter-out-inactive-and-not-approved.tgz#d9a308802669391d33cd6321514b47a174abdb32"
+  integrity sha512-Kv6pAjzt+Od8TiNbchMd85bv6w8RNKP552AATGBkLO3VccvpWSxCsP5x4wjI1L3i/P+emvucQ5o3fARBYa8tvg==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-7354](https://tools.hmcts.net/jira/browse/EUI-7354)

### Change description ###
Upgrade `@hmcts/ccd-case-ui-toolkit` dependency to version `6.10.7-manage-case-flags-filter-out-inactive-and-not-approved`, for filtering out "Inactive" and "Not approved" flags from "Manage case flags" page.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
