### PR TITLE
EUI-8069: Case Flags - Show selected language for "Language Interpreter" case flag types

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@angular/platform-browser-dynamic": "^11.2.14",
     "@angular/router": "^11.2.14",
     "@edium/fsm": "^2.1.2",
-    "@hmcts/ccd-case-ui-toolkit": "6.13.10-f",
+    "@hmcts/ccd-case-ui-toolkit": "6.13.10-case-flags-show-language-for-interpreter-flag-types",
     "@hmcts/ccpay-web-component": "5.0.10-beta14",
     "@hmcts/frontend": "0.0.39-alpha",
     "@hmcts/media-viewer": "2.7.18-RC.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,10 +1467,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@hmcts/ccd-case-ui-toolkit@6.13.10-f":
-  version "6.13.10-f"
-  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-6.13.10-f.tgz#db1ff3bac9a1066a6e911fef5b6b80cc4efea138"
-  integrity sha512-6G4NZ3Twb5+7YN8KHPLgr0KOcABkVeFYXPNSaBD0IKRJArQZvHTPbczPkfE+d8fPQha9Q7+Mr5RQi4XxSFCtYQ==
+"@hmcts/ccd-case-ui-toolkit@6.13.10-case-flags-show-language-for-interpreter-flag-types":
+  version "6.13.10-case-flags-show-language-for-interpreter-flag-types"
+  resolved "https://registry.yarnpkg.com/@hmcts/ccd-case-ui-toolkit/-/ccd-case-ui-toolkit-6.13.10-case-flags-show-language-for-interpreter-flag-types.tgz#41dcf42cfcb9ad6d0666f183c2b4b173487d2742"
+  integrity sha512-W9dKk63UlAWs+fn2aSDftiDOwetcPgLbvmT5HTLPfdZF+960pD8ZsiQCQO1UW7OB/afun+ipe9mNz42UWF6yPQ==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-8069](https://tools.hmcts.net/jira/browse/EUI-8069)

### Change description ###
Upgrade `@hmcts/ccd-case-ui-toolkit` dependency to version `6.13.10-case-flags-show-language-for-interpreter-flag-types`, for fixing display of "Language Interpreter" flags in the Case Flags tabular view.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
