### PR TITLE
Added test scenario for invalid date error msg

### DIFF
--- a/test_codecept/e2e/features/app/TCCreateCase.feature
+++ b/test_codecept/e2e/features/app/TCCreateCase.feature
@@ -76,8 +76,6 @@ Feature: Test case type case creation and case details validations
         Then I see case details page
         Then Validate Case event next step trigger actions
 
-
-@codecept_test
     Scenario: Validate update form page click on next step trigger actions
         When I click on search button
         Then Search page should be displayed
@@ -88,6 +86,14 @@ Feature: Test case type case creation and case details validations
         Then I see case details page
         When I start case next step "Update case"
         Then Validate Case event update populating form page
+
+    Scenario: Validate invalid date error message
+        When I click on primary navigation header tab "Create case", I see selected tab page displayed
+        Then Create case page should be displayed
+        When I start case with jurisdiction "Family Divorce" case type "XUI Test Case type" and event "Create a case"
+        Then I am on case form page
+        When I create case with invalid date
+        Then I see error message of type "validation" displayed with message "Date is not valid"
 
 
 

--- a/test_codecept/e2e/features/pageObjects/common/CaseManager.js
+++ b/test_codecept/e2e/features/pageObjects/common/CaseManager.js
@@ -147,6 +147,27 @@ class CaseManager {
         this.caseEditPage.caseEventApiResponse = null;
     }
 
+    async createCaseWithInvalidDate(caseData, isAccessibilityTest, tcTypeStatus) {
+        this.caseData = caseData;
+    
+        let page = tcTypeStatus ? 0 : "null";
+    
+        for(let i=0; i<2; i++) {
+            page = tcTypeStatus ? i : "null";
+    
+            await BrowserWaits.retryWithActionCallback(async () => {
+                let isNextPageDisplayed = await this._formFillPage(page);
+                if (!isNextPageDisplayed) {
+                    return;
+                }
+            });
+    
+            await BrowserWaits.waitForSeconds(2);
+        }
+    
+        this.caseEditPage.caseEventApiResponse = null;
+    }     
+
     async submitCase(isAccessibilityTest){
         var checkYouranswers = $(".check-your-answers");
         var isCheckYourAnswersPage = await checkYouranswers.isPresent();

--- a/test_codecept/e2e/features/step_definitions/errorValidation.steps.js
+++ b/test_codecept/e2e/features/step_definitions/errorValidation.steps.js
@@ -29,6 +29,12 @@ const headerPage = require("../pageObjects/headerPage");
             } else if (errorTypePage.includes('message')){
                 expect(await exuiErrorMessage.isDisplayed()).to.be.true;
                 expect(await exuiErrorMessage.isMessageDisplayedInSummary(errorMessage),'Message diaplayed does noyt include expected').to.be.true
+
+            } else if (errorTypePage.includes('validation')) {
+                const validationError = $(`.validation-error`);
+                await BrowserWaits.waitForElement(validationError);
+                const validationMessage = await validationError.getText();
+                expect(validationMessage).to.include(errorMessage);    
                 
             } else {
                 throw new Error(`${errorType} is not recognised or not implemented in step definition of tests`);

--- a/test_codecept/e2e/features/step_definitions/testCaseType.steps.js
+++ b/test_codecept/e2e/features/step_definitions/testCaseType.steps.js
@@ -84,6 +84,15 @@ var { defineSupportCode } = require('cucumber');
         await caseManager.createCase(caseData, false);
     });
 
+    When('I create case with invalid date', async function () {
+        var caseData = {
+            "Reference": "1610530255167708",
+            "Appicant Postcode": "SW19 8JW",
+            "Date": "01-01-0000"
+        };
+        await caseManager.createCaseWithInvalidDate(caseData, false);
+    });    
+
     Then('Should be able to see check your answers summary page links', async function () {
         await caseEditPage.validateSummeryPageLinks();
     });


### PR DESCRIPTION
### JIRA link (if applicable) ###
[EUI-8199](https://tools.hmcts.net/jira/browse/EUI-8199)


### Change description ###
Added new test scenario that inputs an invalid year (0000) in the 'Date' field and verifies that the correct error message shows up - it doesn't simply change '0000' to '1900' and continue.

Added new error type 'validation error' to errorValidation.steps

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
