### PR TITLE
Added err msg validation for exceeding char limit in solicitor reference

### DIFF
--- a/test_codecept/e2e/features/app/TCCreateCase.feature
+++ b/test_codecept/e2e/features/app/TCCreateCase.feature
@@ -88,6 +88,14 @@ Feature: Test case type case creation and case details validations
         Then I see case details page
         When I start case next step "Update case"
         Then Validate Case event update populating form page
+@callback_error
+    Scenario: Validate civil claim callback error
+        When I click on primary navigation header tab "Create case", I see selected tab page displayed
+        Then Create case page should be displayed
+        When I start case with jurisdiction "Civil" case type "Civil" and event "Create claim - Specified"
+        Then I am on case form page
+        When I fill in reference number
+        Then I see error message "exceed maximum length 24"
 
 
 

--- a/test_codecept/e2e/features/pageObjects/common/CaseManager.js
+++ b/test_codecept/e2e/features/pageObjects/common/CaseManager.js
@@ -12,6 +12,7 @@ const config = require('../../../config/functional.conf');
 
 const headerPage = require('../headerPage');
 const { LOG_LEVELS } = require('../../../support/constants');
+const { sleep } = require('../../../../codeceptCommon/browser');
 class CaseManager {
 
     constructor() {
@@ -215,6 +216,17 @@ class CaseManager {
     async AmOnChekYourAnswersPage() {
         await BrowserWaits.retryWithActionCallback(async () => {
             expect(await this.checkYourAnswers.isPresent()).to.be.true;
+        });
+    }
+
+    async fillReference(){
+        await BrowserWaits.retryWithActionCallback(async () => {
+            let referenceField = $('#solicitorReferences_applicantSolicitor1Reference');
+            await this.continueBtn.click();
+            await BrowserWaits.waitForSpinnerToDissappear();
+            await this.continueBtn.click();
+            await referenceField.sendKeys('123456789012345678901234567890');
+            await this.continueBtn.click();
         });
     }
 

--- a/test_codecept/e2e/features/step_definitions/caseManager.steps.js
+++ b/test_codecept/e2e/features/step_definitions/caseManager.steps.js
@@ -75,6 +75,10 @@ const creatCaseStepTimeout = 600*1000;
         await caseManager.submitCase(false);
     });
 
+    When('I fill in reference number', async function(){
+        await caseManager.fillReference();
+    });
+
     Then('I see case details page', async function () {
         await caseManager.AmOnCaseDetailsPage();
     });

--- a/test_codecept/e2e/features/step_definitions/errorValidation.steps.js
+++ b/test_codecept/e2e/features/step_definitions/errorValidation.steps.js
@@ -51,6 +51,13 @@ const headerPage = require("../pageObjects/headerPage");
         });
     });
 
-
+    Then('I see error message {string}', async function (errorMessage){
+        await BrowserWaits.retryWithActionCallback(async () => {
+        const errorField = $(`.error-message`);
+        await BrowserWaits.waitForElement(errorField);
+        const errorFieldMessage = await errorField.getText();
+        expect(errorFieldMessage).to.include(errorMessage);
+    });
+    });
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[EUI-8182](https://tools.hmcts.net/jira/browse/EUI-8182)

### Change description ###

Added test scenario to ensure the correct error message shows up when exceeding the 24 character limit in solicitor reference field

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
