### PR TITLE
caseDetailsCheck now validates all tabs, not just tab 2

### DIFF
--- a/test_codecept/e2e/features/pageObjects/caseEditPage.js
+++ b/test_codecept/e2e/features/pageObjects/caseEditPage.js
@@ -149,25 +149,32 @@ class caseEditPage {
     async caseDetailsCheck() {
         let caseDetailsRes = await CcdApi.getCaseResultsResponse();
         this.caseDetailsTabs = $$("mat-tab-body table tbody>div>tbody");
-        await element(by.xpath("//mat-tab-header//div[contains(text(),'Tab 2')]")).click();
-        await BrowserWaits.waitForSeconds(1);
-        let fieldCount = await this.caseDetailsTabs.count();
-        let tabName = "Tab 2";
-        let tab = await caseDetailsRes.tabs.find(tab => tab.label == tabName);
-        for (let count = 0; count < fieldCount; count++) {
-            let complexFieldTable = await this.caseDetailsTabs.get(count).element(by.xpath('./*'));
-            let thCF = complexFieldTable.$$("tr th");
-            let tdCF = complexFieldTable.$$("tr td");
-            let webTableLabel = await thCF.getText();
-            let value = await tdCF.getText();
-            let field = await tab.fields.find(tab => tab.label == webTableLabel);
-            if (field.value && value && field.value.length > 0) {
-                let resKeyVal = await this._getKeyVal(field);
-                let fieldStatus = resKeyVal == value && field.label == webTableLabel;
-                expect(true, `${resKeyVal} is not present in the web`).to.eql(fieldStatus);
-            } else {
-                let fieldLabelStatus = field.label == webTableLabel;
-                expect(true, `${field.label} is not present in the web`).to.eql(fieldLabelStatus);
+        let tabHeaders = await $$("mat-tab-header .mat-tab-label");
+        let numberOfTabs = await tabHeaders.count();
+
+        for (let tabIndex = 0; tabIndex < numberOfTabs; tabIndex++) {
+            let tabHeader = tabHeaders.get(tabIndex);
+            let tabName = await tabHeader.getText();
+            await tabHeader.click();
+            await BrowserWaits.waitForSeconds(1);
+
+            let fieldCount = await this.caseDetailsTabs.count();
+            let tab = await caseDetailsRes.tabs.find(tab => tab.label == tabName);
+            for (let count = 0; count < fieldCount; count++) {
+                let complexFieldTable = await this.caseDetailsTabs.get(count).element(by.xpath('./*'));
+                let thCF = complexFieldTable.$$("tr th");
+                let tdCF = complexFieldTable.$$("tr td");
+                let webTableLabel = await thCF.getText();
+                let value = await tdCF.getText();
+                let field = await tab.fields.find(tab => tab.label == webTableLabel);
+                if (field.value && value && field.value.length > 0) {
+                    let resKeyVal = await this._getKeyVal(field);
+                    let fieldStatus = resKeyVal == value && field.label == webTableLabel;
+                    expect(true, `${resKeyVal} is not present in the web`).to.eql(fieldStatus);
+                } else {
+                    let fieldLabelStatus = field.label == webTableLabel;
+                    expect(true, `${field.label} is not present in the web`).to.eql(fieldLabelStatus);
+                }
             }
         }
     }


### PR DESCRIPTION
### Change description ###

Updated the checkCaseDetails function function to loop through and validate whether the case details shown in each tab match the case details fetched from the api. Previously this would only validate 'tab 2'

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
