### PR TITLE
Added test to verify search filters are retained

### DIFF
--- a/test_codecept/e2e/features/app/TCSearchCaseandCaseList.feature
+++ b/test_codecept/e2e/features/app/TCSearchCaseandCaseList.feature
@@ -1,4 +1,4 @@
-@fullfunctional @codecept_enabled @codecept_enabled 
+@fullfunctional @test @codecept_enabled 
 Feature: Test case type case list and find case workflow
 
   Background:
@@ -60,4 +60,15 @@ Feature: Test case type case list and find case workflow
         Then I see results returned
         When I open first case in search results
         Then I see case details page
+
+    Scenario: Search filters being retained
+        When I click on search button
+        Then Search page should be displayed
+        When I enter search fields jurisdiction "Family Divorce" case type "XUI Test Case type dev"
+        When I click apply to perform case search
+        Then I see results returned
+        When I open first case in search results
+        Then I see case details page
+        When I click on search button
+        Then I verify search filters have jurisdiction "Family Divorce" and case type "XUI Test Case type dev"
 

--- a/test_codecept/e2e/features/step_definitions/searchCase.steps.js
+++ b/test_codecept/e2e/features/step_definitions/searchCase.steps.js
@@ -225,6 +225,24 @@ const RuntimeTestData = require("../../support/runtimeTestData");
   });
 });
 
+Then('I verify search filters have jurisdiction {string} and case type {string}', async function (expectedJurisdiction, expectedCaseType) {
+  await BrowserWaits.retryWithActionCallback(async () => {
+    try {
+      const jurisdictionIndex = await searchPage.jurisdiction.getAttribute('value');
+      const actualJurisdiction = await searchPage.jurisdiction.$(`option[value="${jurisdictionIndex}"]`).getText();
+      const caseTypeIndex = await searchPage.caseType.getAttribute('value');
+      const actualCaseType = await searchPage.caseType.$(`option[value="${caseTypeIndex}"]`).getText();
+
+      expect(actualJurisdiction).to.equal(expectedJurisdiction, `Jurisdiction is not as expected. Expected: ${expectedJurisdiction}, Actual: ${actualJurisdiction}`);
+      expect(actualCaseType).to.equal(expectedCaseType, `Case Type is not as expected. Expected: ${expectedCaseType}, Actual: ${actualCaseType}`);
+    } catch (err) {
+      await CucumberReporter.AddMessage("Retrying with page refresh", LOG_LEVELS.Info);
+      await headerPage.refreshBrowser();
+      throw new Error(err);
+    }
+  });
+});
+
 Then(/^Case details should be displayed based on selected search criteria$/, async function () {
   var searchPage = new SearchPage();
   expect(await searchPage.amOnPage()).to.be.true;


### PR DESCRIPTION
### JIRA link (if applicable) ###

[EUI-8195](https://tools.hmcts.net/jira/browse/EUI-8195)

### Change description ###

Created new test scenario in TCSearchCaseAndCaseList.feature that searches, opens up case details, then returns to search page to check that the filters were retained. New step function created for this scenario.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
