### PR TITLE
Fix for big cot-539

### DIFF
--- a/src/hearings/converters/hearing-specific-date.answer.converter.ts
+++ b/src/hearings/converters/hearing-specific-date.answer.converter.ts
@@ -13,7 +13,7 @@ export class HearingSpecificDateAnswerConverter implements AnswerConverter {
   }
 
   private createAnswer(state: State): string {
-    let specificDateSelection: string = '';
+    let specificDateSelection: string = RadioOptions.NO;
     let earliestHearingDate: string = '';
     let latestHearingDate: string = '';
     const hearingWindow = state.hearingRequest.hearingRequestMainModel.hearingDetails.hearingWindow;


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/COT-539

### Change description ###
Fix for big cot-539 - default date field to 'No' rather than empty string in hearing-specific-date.answer.converter.ts

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
