### PR TITLE
EUI-9005 Hearings tab visibility based on roles

### DIFF
--- a/src/cases/containers/case-viewer-container/case-viewer-container.component.spec.ts
+++ b/src/cases/containers/case-viewer-container/case-viewer-container.component.spec.ts
@@ -30,143 +30,178 @@ class CaseViewerComponent {
   @Input() public appendedTabs: CaseTab[] = [];
 }
 
+const CASE_VIEW: CaseView = {
+  events: [],
+  triggers: [],
+  case_id: '1234567890123456',
+  case_type: {
+    id: 'Benefit',
+    name: 'Test Address Book Case',
+    jurisdiction: {
+      id: 'SSCS',
+      name: 'SSCS'
+    },
+    printEnabled: true
+  },
+  channels: [],
+  state: {
+    id: 'CaseCreated',
+    name: 'Case created'
+  },
+  tabs: [
+    {
+      id: 'NameTab',
+      label: 'Name',
+      order: 2,
+      fields: [
+        Object.assign(new CaseField(), {
+          id: 'PersonFirstName',
+          label: 'First name',
+          display_context: 'OPTIONAL',
+          field_type: {
+            id: 'Text',
+            type: 'Text'
+          },
+          order: 2,
+          value: 'Janet',
+          show_condition: '',
+          hint_text: ''
+        }),
+        Object.assign(new CaseField(), {
+          id: 'PersonLastName',
+          label: 'Last name',
+          display_context: 'OPTIONAL',
+          field_type: {
+            id: 'Text',
+            type: 'Text'
+          },
+          order: 1,
+          value: 'Parker',
+          show_condition: 'PersonFirstName="Jane*"',
+          hint_text: ''
+        }),
+        Object.assign(new CaseField(), {
+          id: 'PersonComplex',
+          label: 'Complex field',
+          display_context: 'OPTIONAL',
+          field_type: {
+            id: 'Complex',
+            type: 'Complex',
+            complex_fields: []
+          },
+          order: 3,
+          show_condition: 'PersonFirstName="Park"',
+          hint_text: ''
+        })
+      ],
+      show_condition: 'PersonFirstName="Janet"'
+    },
+    {
+      id: 'HistoryTab',
+      label: 'History',
+      order: 1,
+      fields: [Object.assign(new CaseField(), {
+        id: 'CaseHistory',
+        label: 'Case History',
+        display_context: 'OPTIONAL',
+        field_type: {
+          id: 'CaseHistoryViewer',
+          type: 'CaseHistoryViewer'
+        },
+        order: 1,
+        value: null,
+        show_condition: '',
+        hint_text: ''
+      })],
+      show_condition: ''
+    },
+    {
+      id: 'SomeTab',
+      label: 'Some Tab',
+      order: 3,
+      fields: [],
+      show_condition: ''
+    }
+  ]
+};
+
+const mockSupportedJurisdictionsService = jasmine.createSpyObj('WASupportedJurisdictionsService', ['getWASupportedJurisdictions']);
+
+class MockFeatureToggleService implements FeatureToggleService {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public getValue<R>(_key: string, _defaultValue: R): Observable<R> {
+    if (_key === 'wa-service-config') {
+      // @ts-ignore
+      return of({ configurations: [{ serviceName: 'SSCS', caseTypes: ['Benefit'], releaseVersion: '3.0' }] });
+    }
+    // @ts-ignore
+    return of([]);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public getValueOnce<R>(_key: string, _defaultValue: R): Observable<R> {
+    return of([{
+      jurisdiction: 'SSCS',
+      caseType: 'Benefit',
+      roles: ['caseworker-sscs-judge', 'caseworker-sscs']
+    }] as unknown as R);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+  public initialize(_user: FeatureUser, _clientId: string): void { }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public isEnabled(_feature: string): Observable<boolean> {
+    return undefined;
+  }
+}
+
+class MockAllocateRoleService {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public manageLabellingRoleAssignment(caseId: string): Observable<string[]> {
+    return of([]);
+  }
+}
+
+const TABS: CaseTab[] = [
+  {
+    id: 'tasks',
+    label: 'Tasks',
+    fields: [],
+    show_condition: null
+  },
+  {
+    id: 'roles-and-access',
+    label: 'Roles and access',
+    fields: [],
+    show_condition: null
+  }
+];
+
+const roles = [
+  'caseworker',
+  'caseworker-ia-iacjudge',
+  'caseworker-sscs',
+  'caseworker-sscs-judge',
+  'caseworker-test',
+  'managePayment',
+  'payments',
+  'payments-refund',
+  'payments-refund-approver',
+  'pui-finance-manager',
+  'pui-organisation-manager',
+  'pui-user-manager'
+];
+
+const rolesWithHearingRoles = [
+  'caseworker',
+  'hearing-manager'
+];
+
 describe('CaseViewerContainerComponent', () => {
   let component: CaseViewerContainerComponent;
   let fixture: ComponentFixture<CaseViewerContainerComponent>;
   let debug: DebugElement;
-
-  const CASE_VIEW: CaseView = {
-    events: [],
-    triggers: [],
-    case_id: '1234567890123456',
-    case_type: {
-      id: 'Benefit',
-      name: 'Test Address Book Case',
-      jurisdiction: {
-        id: 'SSCS',
-        name: 'SSCS'
-      },
-      printEnabled: true
-    },
-    channels: [],
-    state: {
-      id: 'CaseCreated',
-      name: 'Case created'
-    },
-    tabs: [
-      {
-        id: 'NameTab',
-        label: 'Name',
-        order: 2,
-        fields: [
-          Object.assign(new CaseField(), {
-            id: 'PersonFirstName',
-            label: 'First name',
-            display_context: 'OPTIONAL',
-            field_type: {
-              id: 'Text',
-              type: 'Text'
-            },
-            order: 2,
-            value: 'Janet',
-            show_condition: '',
-            hint_text: ''
-          }),
-          Object.assign(new CaseField(), {
-            id: 'PersonLastName',
-            label: 'Last name',
-            display_context: 'OPTIONAL',
-            field_type: {
-              id: 'Text',
-              type: 'Text'
-            },
-            order: 1,
-            value: 'Parker',
-            show_condition: 'PersonFirstName="Jane*"',
-            hint_text: ''
-          }),
-          Object.assign(new CaseField(), {
-            id: 'PersonComplex',
-            label: 'Complex field',
-            display_context: 'OPTIONAL',
-            field_type: {
-              id: 'Complex',
-              type: 'Complex',
-              complex_fields: []
-            },
-            order: 3,
-            show_condition: 'PersonFirstName="Park"',
-            hint_text: ''
-          })
-        ],
-        show_condition: 'PersonFirstName="Janet"'
-      },
-      {
-        id: 'HistoryTab',
-        label: 'History',
-        order: 1,
-        fields: [Object.assign(new CaseField(), {
-          id: 'CaseHistory',
-          label: 'Case History',
-          display_context: 'OPTIONAL',
-          field_type: {
-            id: 'CaseHistoryViewer',
-            type: 'CaseHistoryViewer'
-          },
-          order: 1,
-          value: null,
-          show_condition: '',
-          hint_text: ''
-        })],
-        show_condition: ''
-      },
-      {
-        id: 'SomeTab',
-        label: 'Some Tab',
-        order: 3,
-        fields: [],
-        show_condition: ''
-      }
-    ]
-  };
-
-  const mockSupportedJurisdictionsService = jasmine.createSpyObj('WASupportedJurisdictionsService', ['getWASupportedJurisdictions']);
-
-  class MockFeatureToggleService implements FeatureToggleService {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public getValue<R>(_key: string, _defaultValue: R): Observable<R> {
-      if (_key === 'wa-service-config') {
-        // @ts-ignore
-        return of({ configurations: [{ serviceName: 'SSCS', caseTypes: ['Benefit'], releaseVersion: '3.0' }] });
-      }
-      // @ts-ignore
-      return of([]);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public getValueOnce<R>(_key: string, _defaultValue: R): Observable<R> {
-      return of([{
-        jurisdiction: 'SSCS',
-        caseType: 'Benefit',
-        roles: ['caseworker-sscs-judge', 'caseworker-sscs']
-      }] as unknown as R);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-    public initialize(_user: FeatureUser, _clientId: string): void { }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public isEnabled(_feature: string): Observable<boolean> {
-      return undefined;
-    }
-  }
-
-  class MockAllocateRoleService {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public manageLabellingRoleAssignment(caseId: string): Observable<string[]> {
-      return of([]);
-    }
-  }
 
   const initialState: State = {
     routerReducer: null,
@@ -189,20 +224,7 @@ describe('CaseViewerContainerComponent', () => {
           active: true,
           email: 'juser4@mailinator.com',
           forename: 'XUI test',
-          roles: [
-            'caseworker',
-            'caseworker-ia-iacjudge',
-            'caseworker-sscs',
-            'caseworker-sscs-judge',
-            'caseworker-test',
-            'managePayment',
-            'payments',
-            'payments-refund',
-            'payments-refund-approver',
-            'pui-finance-manager',
-            'pui-organisation-manager',
-            'pui-user-manager'
-          ],
+          roles: roles,
           uid: 'd90ae606-98e8-47f8-b53c-a7ab77fde22b',
           surname: 'judge'
         },
@@ -211,20 +233,6 @@ describe('CaseViewerContainerComponent', () => {
       decorate16digitCaseReferenceSearchBoxInHeader: false
     }
   };
-  const TABS: CaseTab[] = [
-    {
-      id: 'tasks',
-      label: 'Tasks',
-      fields: [],
-      show_condition: null
-    },
-    {
-      id: 'roles-and-access',
-      label: 'Roles and access',
-      fields: [],
-      show_condition: null
-    }
-  ];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -275,10 +283,150 @@ describe('CaseViewerContainerComponent', () => {
     expect((tasksTab.querySelector('.mat-tab-label-content') as HTMLElement).innerText).toBe('Tasks');
     expect((roleAndAccessTab.querySelector('.mat-tab-label-content') as HTMLElement).innerText).toBe('Roles and access');
   });
+});
 
-  it('should return Hearings as the last tab', () => {
-    component.appendedTabs$.subscribe((tab) =>
-      expect(tab[0].id).toBe('hearings')
+describe('CaseViewerContainerComponent - Hearings tab visible', () => {
+  let component: CaseViewerContainerComponent;
+  let fixture: ComponentFixture<CaseViewerContainerComponent>;
+
+  const initialState: State = {
+    routerReducer: null,
+    appConfig: {
+      config: {},
+      termsAndCondition: null,
+      loaded: true,
+      loading: true,
+      termsAndConditions: null,
+      isTermsAndConditionsFeatureEnabled: null,
+      useIdleSessionTimeout: null,
+      userDetails: {
+        sessionTimeout: {
+          idleModalDisplayTime: 0,
+          totalIdleTime: 0
+        },
+        canShareCases: true,
+        userInfo: {
+          id: '',
+          active: true,
+          email: 'juser4@mailinator.com',
+          forename: 'XUI test',
+          roles: rolesWithHearingRoles,
+          uid: 'd90ae606-98e8-47f8-b53c-a7ab77fde22b',
+          surname: 'judge'
+        },
+        roleAssignmentInfo: []
+      },
+      decorate16digitCaseReferenceSearchBoxInHeader: false
+    }
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, StoreModule.forRoot(reducers), MatTabsModule, BrowserAnimationsModule],
+      providers: [
+        provideMockStore({ initialState }),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                case: CASE_VIEW
+              }
+            }
+          }
+        },
+        { provide: FeatureToggleService, useClass: MockFeatureToggleService },
+        { provide: AllocateRoleService, useClass: MockAllocateRoleService },
+        { provide: WASupportedJurisdictionsService, useValue: mockSupportedJurisdictionsService }
+      ],
+      declarations: [CaseViewerContainerComponent, CaseViewerComponent]
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CaseViewerContainerComponent);
+    mockSupportedJurisdictionsService.getWASupportedJurisdictions.and.returnValue(of(['IA', 'SSCS']));
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should display Hearings tab', () => {
+    component.appendedTabs$.subscribe((tabs) =>
+      expect(tabs[0].id).toEqual('hearings')
+    );
+  });
+});
+
+describe('CaseViewerContainerComponent - Hearings tab hidden', () => {
+  let component: CaseViewerContainerComponent;
+  let fixture: ComponentFixture<CaseViewerContainerComponent>;
+
+  const initialState: State = {
+    routerReducer: null,
+    appConfig: {
+      config: {},
+      termsAndCondition: null,
+      loaded: true,
+      loading: true,
+      termsAndConditions: null,
+      isTermsAndConditionsFeatureEnabled: null,
+      useIdleSessionTimeout: null,
+      userDetails: {
+        sessionTimeout: {
+          idleModalDisplayTime: 0,
+          totalIdleTime: 0
+        },
+        canShareCases: true,
+        userInfo: {
+          id: '',
+          active: true,
+          email: 'juser4@mailinator.com',
+          forename: 'XUI test',
+          roles: roles,
+          uid: 'd90ae606-98e8-47f8-b53c-a7ab77fde22b',
+          surname: 'judge'
+        },
+        roleAssignmentInfo: []
+      },
+      decorate16digitCaseReferenceSearchBoxInHeader: false
+    }
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule, StoreModule.forRoot(reducers), MatTabsModule, BrowserAnimationsModule],
+      providers: [
+        provideMockStore({ initialState }),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              data: {
+                case: CASE_VIEW
+              }
+            }
+          }
+        },
+        { provide: FeatureToggleService, useClass: MockFeatureToggleService },
+        { provide: AllocateRoleService, useClass: MockAllocateRoleService },
+        { provide: WASupportedJurisdictionsService, useValue: mockSupportedJurisdictionsService }
+      ],
+      declarations: [CaseViewerContainerComponent, CaseViewerComponent]
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CaseViewerContainerComponent);
+    mockSupportedJurisdictionsService.getWASupportedJurisdictions.and.returnValue(of(['IA', 'SSCS']));
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should not display the Hearings tab', () => {
+    component.appendedTabs$.subscribe((tabs) =>
+      expect(tabs.length).toEqual(0)
     );
   });
 });

--- a/src/cases/containers/case-viewer-container/case-viewer-container.component.ts
+++ b/src/cases/containers/case-viewer-container/case-viewer-container.component.ts
@@ -8,6 +8,7 @@ import { Observable } from 'rxjs/Observable';
 import { catchError, map } from 'rxjs/operators';
 import { AppUtils } from '../../../app/app-utils';
 import { AppConstants } from '../../../app/app.constants';
+import { UserRole } from '../../../app/models/user-details.model';
 import * as fromRoot from '../../../app/store';
 import { AllocateRoleService } from '../../../role-access/services';
 import { WAFeatureConfig } from '../../../work-allocation/models/common/service-config.model';
@@ -96,14 +97,20 @@ export class CaseViewerContainerComponent implements OnInit {
   }
 
   private appendedCaseViewTabs(): Observable<CaseTab[]> {
-    return this.featureToggleService.getValueOnce<FeatureVariation[]>(AppConstants.FEATURE_NAMES.mcHearingsFeature, []).pipe(
-      map((featureVariations: FeatureVariation[]) => {
+    return combineLatest([
+      this.featureToggleService.getValueOnce<FeatureVariation[]>(AppConstants.FEATURE_NAMES.mcHearingsFeature, []),
+      this.userRoles$
+    ]).pipe(
+      map(([featureVariations, userRoles]) => {
         const jurisdictionId = this.caseDetails.case_type.jurisdiction.id;
         const caseTypeId = this.caseDetails.case_type.id;
         const hasMatchedPermissions = featureVariations.some((featureVariation) =>
           Utils.hasMatchedJurisdictionAndCaseType(featureVariation, jurisdictionId, caseTypeId)
         );
-        return hasMatchedPermissions ? this.appendedTabs : [];
+        const hasHearingRole = userRoles.includes(UserRole.HearingViewer) ||
+          userRoles.includes(UserRole.ListedHearingViewer) ||
+          userRoles.includes(UserRole.HearingManager);
+        return (hasMatchedPermissions && hasHearingRole) ? this.appendedTabs : [];
       })
     );
   }

--- a/test_codecept/ngIntegration/tests/features/hearings/hearingsTabDisplayControls.feature
+++ b/test_codecept/ngIntegration/tests/features/hearings/hearingsTabDisplayControls.feature
@@ -25,7 +25,7 @@ Feature: Hearings: Hearings tab display controls
 
     Scenario: Request hearing button not displayed with missing roles
         Given I set MOCK with user details
-            | roles        | caseworker-privatelaw,caseworker-privatelaw-courtadmin,case-allocator |
+            | roles | caseworker-privatelaw,caseworker-privatelaw-courtadmin,case-allocator,hearing-viewer |
             | roleCategory | LEGAL_OPERATIONS                                                      |
 
         # Given I set MOCK person with user "IAC_CaseOfficer_R2" and roles "<Roles>,task-supervisor,case-allocator"
@@ -45,9 +45,9 @@ Feature: Hearings: Hearings tab display controls
         Then I do not see Request a hearing button in hearings tab page
 
 
-    Scenario Outline: hearing tab not displayed jurisdiction <jurisdiction>, case type <caseType> not feature toggled on
+    Scenario Outline: hearing tab not displayed jurisdiction <jurisdiction>, case type <caseType> and roles not feature toggled on
         Given I set MOCK with user details
-            | roles        | caseworker-privatelaw,caseworker-privatelaw-courtadmin,case-allocator,hearing-manager |
+            | roles        | caseworker-privatelaw,caseworker-privatelaw-courtadmin,case-allocator,<role> |
             | roleCategory | LEGAL_OPERATIONS                                                                      |
 
         # Given I set MOCK person with user "IAC_CaseOfficer_R2" and roles "<Roles>,task-supervisor,case-allocator"
@@ -65,8 +65,9 @@ Feature: Hearings: Hearings tab display controls
         # Then debug sleep minutes 20
         Then I see case details tab label "Hearings" is displayed is "false"
         Examples:
-            | jurisdiction | caseType | 
-            | dummy  | dummy  | 
-            | PRIVATELAW | dummy |
-            | dummy | PRLAPPS |
+            |role| jurisdiction | caseType | 
+            | hearing-manager | dummy | dummy |
+            | hearing-viewer| PRIVATELAW | dummy |
+            | hearing-manager | dummy | PRLAPPS |
+            | dummy | PRIVATELAW | PRLAPPS |
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/EUI-9005


### Change description ###
Add logic to hide hearing tab for users who don't have hearing roles


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
