### PR TITLE
SourceMap fix for MC after node upgrade

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -16,6 +16,7 @@
             "aot": true,
             "buildOptimizer": true,
             "outputPath": "dist/rpx-exui",
+            "sourceMap": true,
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/EXUI-1186

Following the recent node upgrade to version 18, the source maps went missing from Chrome Dev Tools

### Change description ###
Modified angular.json file under the project root  and added extra setting of sourceMap : true to build section

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
