### PR TITLE
Added unique tab text to document viewer

### DIFF
--- a/src/app/components/media-viewer-wrapper/media-viewer-wrapper.component.ts
+++ b/src/app/components/media-viewer-wrapper/media-viewer-wrapper.component.ts
@@ -3,6 +3,7 @@ import { WindowService } from '@hmcts/ccd-case-ui-toolkit';
 import { FeatureToggleService } from '@hmcts/rpx-xui-common-lib';
 import { Observable } from 'rxjs';
 import { SessionStorageService } from '../../services/session-storage/session-storage.service';
+import { Title } from '@angular/platform-browser';
 
 const MEDIA_VIEWER = 'media-viewer-info';
 
@@ -28,7 +29,8 @@ export class MediaViewerWrapperComponent implements OnInit {
   public constructor(
         private readonly windowService: WindowService,
         private readonly featureToggleService: FeatureToggleService,
-        private readonly sessionStorageService: SessionStorageService
+        private readonly sessionStorageService: SessionStorageService,
+        private readonly titleService: Title
   ) {}
 
   public async ngOnInit() {
@@ -62,6 +64,8 @@ export class MediaViewerWrapperComponent implements OnInit {
     this.icpJurisdictions$ = this.featureToggleService.getValue('icp-jurisdictions', []);
     this.icpEnabled$ = this.featureToggleService.isEnabled('icp-enabled');
     this.enableRedactSearch$ = this.featureToggleService.isEnabled('enable-redact-search');
+
+    this.titleService.setTitle('View Document - '+ this.mediaFilename);
   }
 
   /**


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/EXUI-190

### Change description ###
On the current system(not CCD or JCM) the judges  tend to have multiple tabs open at the same time for all the different cases they are working on during the day, They want the name of each tab to be unique so that the user has an idea of what case is on what tab to ease navigation.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
