### PR TITLE
EUI-9141/EUI-9142: Case Flags v2 - Case-level flag types not being retrieved

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@angular/platform-browser-dynamic": "^15.2.9",
     "@angular/router": "^15.2.9",
     "@edium/fsm": "^2.1.2",
-    "@hmcts/ccd-case-ui-toolkit": "7.0.3-case-flags-v2-1-release",
+    "@hmcts/ccd-case-ui-toolkit": "7.0.3-case-flags-v2-1-case-level-flags-fix",
     "@hmcts/ccpay-web-component": "6.0.2",
     "@hmcts/frontend": "0.0.50-alpha",
     "@hmcts/media-viewer": "2.10.1-RC.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,12 +2615,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hmcts/ccd-case-ui-toolkit@npm:7.0.3-case-flags-v2-1-release":
-  version: 7.0.3-case-flags-v2-1-release
-  resolution: "@hmcts/ccd-case-ui-toolkit@npm:7.0.3-case-flags-v2-1-release"
+"@hmcts/ccd-case-ui-toolkit@npm:7.0.3-case-flags-v2-1-case-level-flags-fix":
+  version: 7.0.3-case-flags-v2-1-case-level-flags-fix
+  resolution: "@hmcts/ccd-case-ui-toolkit@npm:7.0.3-case-flags-v2-1-case-level-flags-fix"
   dependencies:
     tslib: ^2.3.0
-  checksum: ff7b77bddc66d5860b3b8d5f77d97b52cecf8662db680aea8f0c5ddca0bc39170534156c6b1832dc5db012fb0d96d5c801fd815d8e45f12e65d90cb277f4bc63
+  checksum: 524b7f395035712d4a85ff05430f9a45b40c4d8a595928e9c76e10214baca2c8e87bb475486a21d154d257ceffa671429011bbda1ddf875864f9f848886eead1
   languageName: node
   linkType: hard
 
@@ -19006,7 +19006,7 @@ __metadata:
     "@angular/platform-browser-dynamic": ^15.2.9
     "@angular/router": ^15.2.9
     "@edium/fsm": ^2.1.2
-    "@hmcts/ccd-case-ui-toolkit": 7.0.3-case-flags-v2-1-release
+    "@hmcts/ccd-case-ui-toolkit": 7.0.3-case-flags-v2-1-case-level-flags-fix
     "@hmcts/ccpay-web-component": 6.0.2
     "@hmcts/frontend": 0.0.50-alpha
     "@hmcts/media-viewer": 2.10.1-RC.1


### PR DESCRIPTION
### Jira link (if applicable)
[EUI-9141](https://tools.hmcts.net/jira/browse/EUI-9141)
[EUI-9142](https://tools.hmcts.net/jira/browse/EUI-9142)

### Change description ###
Upgrade `@hmcts/ccd-case-ui-toolkit` dependency to version `7.0.3-case-flags-v2-1-case-level-flags-fix`, for testing bug fix for EUI-9141/EUI-9142.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
