### PR TITLE
AAT: Redis - move to Standard before Premium

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,4 +1,4 @@
 # Redis Variables
-redis_sku_name = "Premium"
-redis_family   = "P"
-redis_capacity = "2"
+redis_sku_name = "Standard"
+redis_family   = "C"
+redis_capacity = "3"


### PR DESCRIPTION
Not able to jump straight to Premium, need to move to Standard first

https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-scale?tabs=scale-up-and-down-with-basic-standard-and-premium#prerequisiteslimitations-of-scaling-azure-cache-for-redis
