### PR TITLE
EXUI-2294: Resolve issue when reloading tab on hearings add edit summary page

### DIFF
--- a/src/hearings/containers/hearing-actuals/hearing-actuals-add-edit-summary/hearing-actuals-add-edit-summary.component.ts
+++ b/src/hearings/containers/hearing-actuals/hearing-actuals-add-edit-summary/hearing-actuals-add-edit-summary.component.ts
@@ -142,6 +142,8 @@ export class HearingActualsAddEditSummaryComponent extends HearingActualsSummary
 
   public haveParticipantsBeenAdded(hearingDay: ActualHearingDayModel): boolean {
     const individualParties = this.individualParties;
-    return individualParties?.length !== hearingDay?.actualDayParties?.length;
+    if (hearingDay && this.individualParties){
+      return individualParties?.length !== hearingDay?.actualDayParties?.length;
+    }
   }
 }


### PR DESCRIPTION
### Jira link

See [EXUI-2294](https://tools.hmcts.net/jira/browse/EXUI-2294)

### Change description

Fix for when the user refreshes on edit summary page and some vars are temp undefined causing continue button to become unusable
