### PR TITLE
EXUI-2300 - Hearing data not cached when editing

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.ts
@@ -96,6 +96,7 @@ export class HearingEditSummaryComponent extends RequestHearingPageFlow implemen
   }
 
   public ngOnInit(): void {
+    console.log('edit summary source file');
     this.caseReference = String(this.hearingRequestMainModel.caseDetails.caseRef).replace(/(\d{4})(\d{4})(\d{4})(\d{4})/, '$1-$2-$3-$4');
     this.status = hearingStatusMappings.find((mapping) => mapping.hmcStatus === this.hearingRequestMainModel.requestDetails?.status)?.exuiDisplayStatus || '';
     this.requestSubmittedDate = moment(this.hearingRequestMainModel?.requestDetails?.timestamp)?.format(HearingDateEnum.DisplayMonth) || '';
@@ -596,11 +597,6 @@ export class HearingEditSummaryComponent extends RequestHearingPageFlow implemen
     if ((hearingWindowHMC?.firstDateTimeMustBe) ||
       (hearingWindowHMC?.dateRangeStart || hearingWindowHMC?.dateRangeEnd)) {
       if (HearingsUtils.hasHearingDatesChanged(this.hearingRequestMainModel.hearingDetails.hearingWindow, this.serviceHearingValuesModel.hearingWindow)){
-        return true;
-      }
-    }
-    if (this.hearingRequestMainModel.hearingDetails.duration){
-      if (HearingsUtils.hasHearingDurationChanged(this.hearingRequestMainModel.hearingDetails.duration, this.serviceHearingValuesModel.duration)){
         return true;
       }
     }


### PR DESCRIPTION
### Jira link

See [EXUI-2300](https://tools.hmcts.net/jira/browse/EXUI-2300)

### Change description

Removed the check for comparing hearing duration using service hearing values against GET hearingDetails response, as per documentation GET hearingDetails response should be used for duration, comparing this against SHV will always result in action needed tag being shown and value not being pre-populated on edit hearing page 

### Testing done

Used test caseID found in ticket on demo, 'action needed' tag is no longer shown against 'Length, date and priority level of hearing' and when user clicks change the value for duration is pre-populated.

