### PR TITLE
Reduce old space setting to 2Gb

### DIFF
--- a/charts/xui-webapp/Chart.yaml
+++ b/charts/xui-webapp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: xui-webapp
 home: https://github.com/hmcts/rpx-xui-webapp
-version: 1.0.18
+version: 1.0.19
 description: Expert UI
 maintainers:
   - name: HMCTS RPX XUI

--- a/charts/xui-webapp/values.yaml
+++ b/charts/xui-webapp/values.yaml
@@ -22,7 +22,7 @@ nodejs:
     REFORM_SERVICE_NAME: xui-webapp
     NODE_ENV: production
     NODE_CONFIG_ENV: production
-    NODE_OPTIONS: --max-old-space-size=8192
+    NODE_OPTIONS: --max-old-space-size=2048
     UV_THREADPOOL_SIZE: 64
     XUI_ENV: preview
     LOGGING: debug
@@ -155,4 +155,3 @@ nodejs:
   ingressHost: ${SERVICE_FQDN}
 idam-pr:
   enabled: false
-


### PR DESCRIPTION
### Change description
Reducing old space size (`--max-old-space-size`) to 2Gb from 8Gb. Pods were requesting 3Gb, so it didn't make sense to tell nodejs that it has a lot more than what was available.

### Testing done

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
