### PR TITLE
Update hearing window dates to always be in the future

### DIFF
--- a/src/hearings/utils/hearings.utils.spec.ts
+++ b/src/hearings/utils/hearings.utils.spec.ts
@@ -8,6 +8,7 @@ import { HearingsUtils } from './hearings.utils';
 import { UnavailabilityRangeModel } from '../models/unavailabilityRange.model';
 import { HearingWindowModel } from '../models/hearingWindow.model';
 import { ServiceHearingValuesModel } from '../models/serviceHearingValues.model';
+import * as moment from 'moment';
 
 describe('HearingsUtils', () => {
   it('should return true if has the right property', () => {
@@ -503,6 +504,96 @@ describe('HearingsUtils', () => {
       expect(
         HearingsUtils.checkHearingPartiesConsistency(hearingRequestMainModel, serviceHearingValuesModel)
       ).toBeFalsy();
+    });
+  });
+  describe('Update the hearing window static data to a future date\'', () => {
+    const mochSHVData = {
+      'hmctsServiceID': 'ABA5',
+      'hmctsInternalCaseName': '1234567812345678 update case internal name',
+      'publicCaseName': 'Case public name',
+      'caseAdditionalSecurityFlag': false,
+      'caseCategories': [
+        {
+          'categoryType': 'caseType',
+          'categoryValue': 'ABA5-PRL',
+          'categoryParent': null
+        },
+        {
+          'categoryType': 'caseSubType',
+          'categoryValue': 'ABA5-PRL',
+          'categoryParent': 'ABA5-PRL'
+        }
+      ],
+      'caseDeepLink': 'https://manage-case-hearings-int.demo.platform.hmcts.net/cases/case-details/1690807693531270#Case File View',
+      'externalCaseReference': '',
+      'caseManagementLocationCode': '283922',
+      'autoListFlag': false,
+      'hearingType': '',
+      'hearingWindow': {
+        'dateRangeStart': '',
+        'dateRangeEnd': '',
+        'firstDateTimeMustBe': '2024-12-18T00:00:00'
+      },
+      'duration': 120,
+      'hearingPriorityType': 'Standard',
+      'numberOfPhysicalAttendees': 0
+    };
+    const mockHMCData = {
+      'requestDetails': {
+        'status': 'LISTED',
+        'timestamp': '2023-11-06T14:01:32.836316',
+        'versionNumber': 1,
+        'hearingRequestID': '2000007311'
+      },
+      'hearingDetails': {
+        'hearingType': 'ABA1-ABC',
+        'hearingWindow': {
+          'dateRangeStart': '2025-12-15T00:00:00',
+          'dateRangeEnd': '2025-12-17T00:00:00',
+          'firstDateTimeMustBe': ''
+        },
+        'duration': 125,
+        'hearingPriorityType': 'ABA1-HPR',
+        'numberOfPhysicalAttendees': 0,
+        'hearingInWelshFlag': false,
+        'hearingLocations': [
+          {
+            'locationType': 'court',
+            'locationId': '827534'
+          }
+        ],
+        'privateHearingRequiredFlag': false,
+        'panelRequirements': {
+          'roleType': [
+            '19',
+            '30'
+          ],
+          'authorisationTypes': [],
+          'authorisationSubType': [],
+          'panelPreferences': [],
+          'panelSpecialisms': []
+        },
+        'hearingIsLinkedFlag': false,
+        'hearingChannels': [
+          'INTER',
+          'VID'
+        ],
+        'autolistFlag': false
+      }
+    };
+    it('SHV static data updated with future dates', () => {
+      const response = mochSHVData;
+      HearingsUtils.resetHearingWindow(response);
+      const expectedYear = new Date().getFullYear();
+      expect(moment(response.hearingWindow.firstDateTimeMustBe).year()).toEqual(expectedYear + 1);
+    });
+
+    it('HMC static data updated with future dates', () => {
+      const response = mockHMCData;
+      HearingsUtils.resetHearingWindow(response);
+      const expectedYear = new Date().getFullYear();
+      expect(moment(response.hearingDetails.hearingWindow.dateRangeStart).year()).toEqual(expectedYear + 1);
+      expect(moment(response.hearingDetails.hearingWindow.dateRangeEnd).year()).toEqual(expectedYear + 1);
     });
   });
 });

--- a/src/hearings/utils/hearings.utils.ts
+++ b/src/hearings/utils/hearings.utils.ts
@@ -231,4 +231,26 @@ export class HearingsUtils {
     const contains = individualHMCPartyIds.some((hmcParty) => individualSHVPartyIds.includes(hmcParty));
     return contains;
   }
+
+  public static modifyHearingDetailsYear(hearingDetails: HearingWindowModel): void {
+    if (hearingDetails?.dateRangeStart) {
+      hearingDetails.dateRangeStart = moment(hearingDetails.dateRangeStart).year(moment().year() + 1).toISOString();
+    }
+    if (hearingDetails?.dateRangeEnd) {
+      hearingDetails.dateRangeEnd = moment(hearingDetails.dateRangeEnd).year(moment().year() + 1).toISOString();
+    }
+    if (hearingDetails?.firstDateTimeMustBe) {
+      hearingDetails.firstDateTimeMustBe = moment(hearingDetails.firstDateTimeMustBe).year(moment().year() + 1).toISOString();
+    }
+    // return modifiedHearingDetails;
+  }
+
+  public static resetHearingWindow(input: any): void {
+    if (input?.hearingWindow) {
+      HearingsUtils.modifyHearingDetailsYear(input.hearingWindow);
+    }
+    if (input?.hearingDetails?.hearingWindow) {
+      HearingsUtils.modifyHearingDetailsYear(input?.hearingDetails?.hearingWindow);
+    }
+  }
 }

--- a/test_codecept/ngIntegration/tests/stepDefinitions/hearingsMock.steps.js
+++ b/test_codecept/ngIntegration/tests/stepDefinitions/hearingsMock.steps.js
@@ -24,6 +24,7 @@ const mockServiceHearingValues = require('../../../backendMock/services/hearings
 
 const jsonUtil = require('../.././../e2e/utils/jsonUtil')
 const path = require('path')
+const { HearingsUtils } = require('../../../../src/hearings/utils/hearings.utils');
 
 function getHearingsMockJsonFromFile(fileName){
   return jsonUtil.getJsonFromFile(path.resolve(__dirname,`../features/hearings/mockData/${fileName}.json`,))
@@ -49,12 +50,14 @@ Given('I set mock case hearings from file {string}', async function (filename) {
 });
 
 Given('I set mock hearing HMC response from file {string}', async function (fileName) {
-  const response = getHearingsMockJsonFromFile(fileName)
+  const response = getHearingsMockJsonFromFile(fileName);
+  HearingsUtils.resetHearingWindow(response);
   await mockClient.setOnGetHearing(response, 200);
 });
 
 Given('I set mock hearing SHV response from file {string}', async function (fileName) {
-  const response = getHearingsMockJsonFromFile(fileName)
+  const response = getHearingsMockJsonFromFile(fileName);
+  HearingsUtils.resetHearingWindow(response);
   await mockClient.setHearingServiceHearingValues(response, 200);
 });
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2666

### Change description

A number of integration tests have been failing as the hard coded dates move from future dates to past dates.  This pr is to automatically ensure these dates are always in the future to prevent these issues from recurring next year.

### Testing done

This is code that will only impact the functional tests, so will be tested in the pr pipeline.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - No
