### PR TITLE
ExUI-2699

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.ts
@@ -178,3 +178,4 @@ export class HearingFacilitiesComponent extends RequestHearingPageFlow implement
     }
   }
 }
+

--- a/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.ts
@@ -120,19 +120,17 @@ export class HearingFacilitiesComponent extends RequestHearingPageFlow implement
   public prepareHearingRequestData() {
     const facilitiesRequired: string[] = (this.hearingFactilitiesForm.controls['addition-securities'] as FormArray).controls
       .filter((control) => control.value.selected).map((mapControl) => mapControl.value.key);
-    if (facilitiesRequired.length > 0) {
-      this.hearingRequestMainModel = {
-        ...this.hearingRequestMainModel,
-        caseDetails: {
-          ...this.hearingRequestMainModel.caseDetails,
-          caseAdditionalSecurityFlag: this.hearingFactilitiesForm.controls['addition-security-required'].value === 'Yes'
-        },
-        hearingDetails: {
-          ...this.hearingRequestMainModel.hearingDetails,
-          facilitiesRequired
-        }
-      };
-    }
+    this.hearingRequestMainModel = {
+      ...this.hearingRequestMainModel,
+      caseDetails: {
+        ...this.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: this.hearingFactilitiesForm.controls['addition-security-required'].value === 'Yes'
+      },
+      hearingDetails: {
+        ...this.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired
+      }
+    };
     const propertiesUpdatedOnPageVisit = this.hearingsService.propertiesUpdatedOnPageVisit;
     if (this.hearingCondition.mode === Mode.VIEW_EDIT) {
       if (propertiesUpdatedOnPageVisit?.hasOwnProperty('caseFlags') &&


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2699

### Change description

The hearing facilities had a check in place, which would only store the changes to the screen when there was at least one additional facility selected.  This prevented changes to the additional security flag from being stored if there were no additional facilities and also prevented all additional facilities from being deleted, as it would require at least one to be in place. 

### Testing done

This has been tested to show that the issue has been resolved and checked in to ensure that no functional tests have been broken. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
