### PR TITLE
EXUI-2706 fix to hearing-edit-summary.component.ts

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.spec.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.spec.ts
@@ -21,6 +21,8 @@ import { HearingsService } from '../../../services/hearings.service';
 import { LocationsDataService } from '../../../services/locations-data.service';
 import * as fromHearingStore from '../../../store';
 import { HearingEditSummaryComponent } from './hearing-edit-summary.component';
+import { ServiceHearingValuesModel } from '../../../models/serviceHearingValues.model';
+import { HearingRequestMainModel } from '../../../models/hearingRequestMain.model';
 
 describe('HearingEditSummaryComponent', () => {
   let component: HearingEditSummaryComponent;
@@ -1447,6 +1449,22 @@ describe('HearingEditSummaryComponent', () => {
     };
 
     const isDifference = component.pageVisitReasonableAdjustmentChangeExists();
+
+    expect(isDifference).toEqual(true);
+  });
+
+  it('should return true as as priority in SHV has been updated', () => {
+    setAfterPageVisitValues();
+    hearingsService.propertiesUpdatedOnPageVisit.afterPageVisit.hearingWindowChangesConfirmed = false;
+    const shvModel: ServiceHearingValuesModel = JSON.parse(JSON.stringify(initialState.hearings.hearingValues.serviceHearingValuesModel));
+    const hmcModel: HearingRequestMainModel = JSON.parse(JSON.stringify(initialState.hearings.hearingRequest.hearingRequestMainModel));
+    shvModel.hearingPriorityType = 'urgent';
+    hmcModel.hearingDetails.hearingPriorityType = 'standard';
+
+    component.serviceHearingValuesModel = shvModel;
+    component.hearingRequestMainModel = hmcModel;
+    component.ngOnInit();
+    const isDifference = hearingsService.propertiesUpdatedOnPageVisit.afterPageVisit.hearingWindowChangesRequired;
 
     expect(isDifference).toEqual(true);
   });

--- a/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.ts
@@ -592,6 +592,7 @@ export class HearingEditSummaryComponent extends RequestHearingPageFlow implemen
         return true;
       }
     }
-    return false;
+
+    return this.hearingRequestMainModel.hearingDetails.hearingPriorityType !== this.serviceHearingValuesModel.hearingPriorityType;
   }
 }

--- a/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.html
+++ b/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.html
@@ -51,7 +51,7 @@
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             <h3 class="govuk-fieldset__heading">
               {{ 'Does the hearing need to take place on a specific date?' | rpxTranslate }}
-              <exui-amendment-label id="hearing-specific-dates-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired"
+              <exui-amendment-label id="hearing-specific-dates-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired && (dateRangeStartChanged || dateRangeEndChanged || firstDateTimeMustBeChanged)"
                 [displayLabel]="amendmentLabelEnum.ACTION_NEEDED">
               </exui-amendment-label>
             </h3>


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2706

### Change description

A test was missing in hearing-edit-summary.component.ts to determine that the hearing timing section had a change in the priority.  As such it didn't identigy that an amendment had been made and did not allow the new priority to be processed. A test has been put in place and the updated status can now be confirmed and processed. 

### Testing done

I tested the change by re-creating the issue.  I dropped the urgent case flag and created a new hearing, with a standard priority.  I then re-applied the urgent case flag and confirmed the new urgent priority in the SHV.  The new value was identified and was acceptible.  On processing the update, the new urgent priority was being passed to HMC.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - no
