### PR TITLE
EXUI-2630 removing the check on length of facilitiesRequired

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.ts
@@ -120,19 +120,17 @@ export class HearingFacilitiesComponent extends RequestHearingPageFlow implement
   public prepareHearingRequestData() {
     const facilitiesRequired: string[] = (this.hearingFactilitiesForm.controls['addition-securities'] as FormArray).controls
       .filter((control) => control.value.selected).map((mapControl) => mapControl.value.key);
-    if (facilitiesRequired.length > 0) {
-      this.hearingRequestMainModel = {
-        ...this.hearingRequestMainModel,
-        caseDetails: {
-          ...this.hearingRequestMainModel.caseDetails,
-          caseAdditionalSecurityFlag: this.hearingFactilitiesForm.controls['addition-security-required'].value === 'Yes'
-        },
-        hearingDetails: {
-          ...this.hearingRequestMainModel.hearingDetails,
-          facilitiesRequired
-        }
-      };
-    }
+    this.hearingRequestMainModel = {
+      ...this.hearingRequestMainModel,
+      caseDetails: {
+        ...this.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: this.hearingFactilitiesForm.controls['addition-security-required'].value === 'Yes'
+      },
+      hearingDetails: {
+        ...this.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired
+      }
+    };
     const propertiesUpdatedOnPageVisit = this.hearingsService.propertiesUpdatedOnPageVisit;
     if (this.hearingCondition.mode === Mode.VIEW_EDIT) {
       if (propertiesUpdatedOnPageVisit?.hasOwnProperty('caseFlags') &&


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2630

### Change description

hearing-facilities was performing a check on the facilitiesRequired lengh, only performing an update if the lengh was greater than 0.  This was preventing the removal of a facility, when it is the only one selected. 

### Testing done

The steps to replicate have been followed and the update can be seen to be working as expected.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change - no
