### PR TITLE
standardising the facilities required when not set for more accurate check

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-edit-summary/additional-facilities-section/additional-facilities-section.component.spec.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/additional-facilities-section/additional-facilities-section.component.spec.ts
@@ -337,4 +337,12 @@ describe('AdditionalFacilitiesSectionComponent', () => {
       expect(component.pageTitleDisplayLabel).toEqual(AmendmentLabelStatus.AMENDED);
     });
   });
+
+  it('should set facilities required correctly', () => {
+    const facilities = ['facility1', 'facility2'];
+    expect((component as any).setFacilitiesRequired(facilities)).toEqual(facilities);
+    expect((component as any).setFacilitiesRequired([])).toBeUndefined();
+    expect((component as any).setFacilitiesRequired(null)).toBeUndefined();
+    expect((component as any).setFacilitiesRequired(undefined)).toBeUndefined();
+  });
 });

--- a/src/hearings/containers/request-hearing/hearing-edit-summary/additional-facilities-section/additional-facilities-section.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/additional-facilities-section/additional-facilities-section.component.ts
@@ -75,16 +75,20 @@ export class AdditionalFacilitiesSectionComponent implements OnInit {
     });
   }
 
+  private setFacilitiesRequired(facilitiesRequired: string[] | null | undefined): string[] | undefined {
+    return facilitiesRequired && facilitiesRequired.length > 0 ? facilitiesRequired : undefined;
+  }
+
   private setAmendmentLabels(): void {
     this.caseAdditionalSecurityFlagChanged = !_.isEqual(
       this.hearingRequestToCompareMainModel.caseDetails?.caseAdditionalSecurityFlag,
       this.hearingRequestMainModel.caseDetails?.caseAdditionalSecurityFlag
     );
 
-    this.facilitiesChanged = !_.isEqual(
-      this.hearingRequestMainModel.hearingDetails?.facilitiesRequired,
-      this.hearingRequestToCompareMainModel.hearingDetails?.facilitiesRequired
-    );
+    const facilitiesRequiredMainModel = this.setFacilitiesRequired(this.hearingRequestMainModel.hearingDetails?.facilitiesRequired);
+    const facilitiesRequiredToCompareMainModel = this.setFacilitiesRequired(this.hearingRequestToCompareMainModel.hearingDetails?.facilitiesRequired);
+
+    this.facilitiesChanged = !_.isEqual(facilitiesRequiredMainModel, facilitiesRequiredToCompareMainModel);
 
     if ((this.nonReasonableAdjustmentChangesRequired && !this.nonReasonableAdjustmentChangesConfirmed) ||
       (this.hearingFacilitiesChangesRequired && !this.hearingFacilitiesChangesConfirmed)) {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2630

### Change description

This is an additional change to this code. It was noted that the amend label on the summary page was not being removed when a change was made and then reverted.  It turns out that after accepting the changes, the facilities required was getting set with an empty array, which was being compared against an initial value of undefined in the compareMainModel.  I have introduced a method to standardise the hearingFacilities to allow for a more accurate comparison. 

### Testing done

Testing has been done to prove the comparison when changes have been made and reverted. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
