### PR TITLE
Disable the continue button when the cancel has been scheduled to prevent multiple requests.

### DIFF
--- a/src/hearings/containers/cancel-hearing/cancel-hearing.component.html
+++ b/src/hearings/containers/cancel-hearing/cancel-hearing.component.html
@@ -37,7 +37,7 @@
                 </div>
               </fieldset>
             </div>
-            <button type="submit" class="govuk-button" data-module="govuk-button">{{ 'Continue' | rpxTranslate }}</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button" [disabled]="buttonDisabled()">{{ 'Continue' | rpxTranslate }}</button>
           </form>
           <p class="govuk-body">
              <a href="javascript:void(0)"

--- a/src/hearings/containers/cancel-hearing/cancel-hearing.component.spec.ts
+++ b/src/hearings/containers/cancel-hearing/cancel-hearing.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, NgZone } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormArray, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -133,11 +133,14 @@ describe('CancelHearingComponent', () => {
   });
 
   it('should call cancelHearingRequest when executeAction is called with a valid form', () => {
-    (component.hearingCancelForm.controls.reasons as FormArray).controls
-      .forEach((reason) => reason.value.selected = true);
-    component.executeContinue();
-    expect(mockHearingService.cancelHearingRequest).toHaveBeenCalled();
-    expect(component.getChosenReasons).toHaveBeenCalled();
+    const ngZone = TestBed.inject(NgZone);
+    ngZone.run(() => {
+      (component.hearingCancelForm.controls.reasons as FormArray).controls
+        .forEach((reason) => reason.value.selected = true);
+      component.executeContinue();
+      expect(mockHearingService.cancelHearingRequest).toHaveBeenCalled();
+      expect(component.getChosenReasons).toHaveBeenCalled();
+    });
   });
 
   it('should be true when calling isFormValid reasons selected', () => {
@@ -183,15 +186,26 @@ describe('CancelHearingComponent', () => {
   });
 
   it('should disable the button when form is valid and submitted', () => {
-    const fb = new FormBuilder();
-    const reasonsArray = component.hearingCancelForm.controls.reasons as FormArray;
-    reasonsArray.clear();
-    reasons.forEach(() => {
-      reasonsArray.push(fb.group({ selected: true }));
+    const ngZone = TestBed.inject(NgZone);
+    ngZone.run(() => {
+      const fb = new FormBuilder();
+      const reasonsArray = component.hearingCancelForm.controls.reasons as FormArray;
+      reasonsArray.clear();
+      reasons.forEach(() => {
+        reasonsArray.push(fb.group({ selected: true }));
+      });
+      fixture.detectChanges();
+      component.executeContinue();
+      expect(component.buttonDisabled()).toBe(true);
     });
-    fixture.detectChanges();
+  });
+
+  it('should reset cancelActioned to false when cancelHearingRequest fails', () => {
+    (component.hearingCancelForm.controls.reasons as FormArray).controls
+      .forEach((reason) => reason.value.selected = true);
+    hearingsService.cancelHearingRequest = jasmine.createSpy().and.returnValue(throwError(''));
     component.executeContinue();
-    expect(component.buttonDisabled()).toBe(true);
+    expect(component.cancelActioned).toBe(false);
   });
 
   it('should call executeContinue on form submit', () => {

--- a/src/hearings/containers/cancel-hearing/cancel-hearing.component.spec.ts
+++ b/src/hearings/containers/cancel-hearing/cancel-hearing.component.spec.ts
@@ -160,4 +160,59 @@ describe('CancelHearingComponent', () => {
     component.executeContinue();
     expect(component.validationErrors).not.toBeNull();
   });
+  it('should enable the button when form is valid', () => {
+    const fb = new FormBuilder();
+    const reasonsArray = component.hearingCancelForm.controls.reasons as FormArray;
+    reasonsArray.clear();
+    reasons.forEach(() => {
+      reasonsArray.push(fb.group({ selected: true }));
+    });
+    fixture.detectChanges();
+    expect(component.buttonDisabled()).toBe(false);
+  });
+
+  it('should enable the button when form is invalid', () => {
+    const fb = new FormBuilder();
+    const reasonsArray = component.hearingCancelForm.controls.reasons as FormArray;
+    reasonsArray.clear();
+    reasons.forEach(() => {
+      reasonsArray.push(fb.group({ selected: false }));
+    });
+    fixture.detectChanges();
+    expect(component.buttonDisabled()).toBe(false);
+  });
+
+  it('should disable the button when form is valid and submitted', () => {
+    const fb = new FormBuilder();
+    const reasonsArray = component.hearingCancelForm.controls.reasons as FormArray;
+    reasonsArray.clear();
+    reasons.forEach(() => {
+      reasonsArray.push(fb.group({ selected: true }));
+    });
+    fixture.detectChanges();
+    component.executeContinue();
+    expect(component.buttonDisabled()).toBe(true);
+  });
+
+  it('should call executeContinue on form submit', () => {
+    spyOn(component, 'executeContinue');
+    const button = fixture.debugElement.nativeElement.querySelector('button[type="submit"]');
+    button.click();
+    expect(component.executeContinue).toHaveBeenCalled();
+  });
+
+  it('should display error message when no reason is selected', () => {
+    component.selectionValid = false;
+    fixture.detectChanges();
+    const errorMessage = fixture.debugElement.nativeElement.querySelector('.govuk-error-message');
+    expect(errorMessage).toBeTruthy();
+    expect(errorMessage.textContent).toContain('Select at least one valid reason');
+  });
+
+  it('should not display error message when a reason is selected', () => {
+    component.selectionValid = true;
+    fixture.detectChanges();
+    const errorMessage = fixture.debugElement.nativeElement.querySelector('.govuk-error-message');
+    expect(errorMessage).toBeFalsy();
+  });
 });

--- a/src/hearings/containers/cancel-hearing/cancel-hearing.component.ts
+++ b/src/hearings/containers/cancel-hearing/cancel-hearing.component.ts
@@ -25,6 +25,7 @@ export class CancelHearingComponent implements OnInit {
   public caseId: string;
   public caseHearing: HearingListModel;
   public showSpinner$: Observable<boolean>;
+  public cancelActioned: boolean = false;
 
   constructor(
     private readonly route: ActivatedRoute,
@@ -106,7 +107,12 @@ export class CancelHearingComponent implements OnInit {
           this.validationErrors = [{ id: 'cancel-request-error', message: cancellationErrorMessage }];
         }
       );
+      this.cancelActioned = true;
     }
+  }
+
+  public buttonDisabled(): boolean {
+    return this.cancelActioned;
   }
 
   public getChosenReasons(): LovRefDataModel[] {

--- a/src/hearings/containers/cancel-hearing/cancel-hearing.component.ts
+++ b/src/hearings/containers/cancel-hearing/cancel-hearing.component.ts
@@ -104,10 +104,13 @@ export class CancelHearingComponent implements OnInit {
             .catch((err) => this.loggerService.error('Error navigating to cases/case-details/caseId/hearings ', err));
         },
         () => {
+          this.cancelActioned = false;
           this.validationErrors = [{ id: 'cancel-request-error', message: cancellationErrorMessage }];
         }
       );
-      this.cancelActioned = true;
+      if (!this.validationErrors) {
+        this.cancelActioned = true;
+      }
     }
   }
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2889

### Change description

The continue button on the cancel page could be pressed multiple times and submit multiple cancel requests to the service which was causing failure messages to be returned.  The button will now be disabled on the successful submission of the cancel request, meaning it can only be selected once. 

### Testing done

The cancel operation was seen to grey out the button after the first click. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - No
