### PR TITLE
prevent an amend label where only change is case flag

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-edit-summary/additional-facilities-section/additional-facilities-section.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/additional-facilities-section/additional-facilities-section.component.ts
@@ -92,7 +92,6 @@ export class AdditionalFacilitiesSectionComponent implements OnInit {
     } else {
       if (this.caseAdditionalSecurityFlagChanged ||
         this.facilitiesChanged ||
-        (this.nonReasonableAdjustmentChangesRequired && this.nonReasonableAdjustmentChangesConfirmed) ||
         (this.hearingFacilitiesChangesRequired && this.hearingFacilitiesChangesConfirmed)) {
         this.pageTitleDisplayLabel = AmendmentLabelStatus.AMENDED;
       }

--- a/src/hearings/containers/request-hearing/hearing-edit-summary/additional-facilities-section/additional-facilities-section.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/additional-facilities-section/additional-facilities-section.component.ts
@@ -1,10 +1,10 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import * as _ from 'lodash';
 import { AmendmentLabelStatus } from '../../../../../hearings/models/hearingsUpdateMode.enum';
 import { HearingsService } from '../../../../../hearings/services/hearings.service';
 import { EditHearingChangeConfig } from '../../../../models/editHearingChangeConfig.model';
 import { HearingRequestMainModel } from '../../../../models/hearingRequestMain.model';
 import { LovRefDataModel } from '../../../../models/lovRefData.model';
+import { HearingsUtils } from '../../../../utils/hearings.utils';
 
 @Component({
   selector: 'exui-additional-facilities-section',
@@ -76,23 +76,22 @@ export class AdditionalFacilitiesSectionComponent implements OnInit {
   }
 
   private setAmendmentLabels(): void {
-    this.caseAdditionalSecurityFlagChanged = !_.isEqual(
-      this.hearingRequestToCompareMainModel.caseDetails?.caseAdditionalSecurityFlag,
-      this.hearingRequestMainModel.caseDetails?.caseAdditionalSecurityFlag
+    const { caseAdditionalSecurityFlagChanged, facilitiesChanged } = HearingsUtils.haveAdditionalFacilitiesChanged(
+      this.hearingRequestMainModel,
+      this.hearingRequestToCompareMainModel
     );
 
-    this.facilitiesChanged = !_.isEqual(
-      this.hearingRequestMainModel.hearingDetails?.facilitiesRequired,
-      this.hearingRequestToCompareMainModel.hearingDetails?.facilitiesRequired
-    );
+    this.caseAdditionalSecurityFlagChanged = caseAdditionalSecurityFlagChanged;
+    this.facilitiesChanged = facilitiesChanged;
+    const additionalFacilitiesChangesMade = caseAdditionalSecurityFlagChanged || facilitiesChanged;
+
+    const AmendedChanges = (additionalFacilitiesChangesMade || (this.hearingFacilitiesChangesRequired && this.hearingFacilitiesChangesConfirmed));
 
     if ((this.nonReasonableAdjustmentChangesRequired && !this.nonReasonableAdjustmentChangesConfirmed) ||
       (this.hearingFacilitiesChangesRequired && !this.hearingFacilitiesChangesConfirmed)) {
       this.pageTitleDisplayLabel = AmendmentLabelStatus.ACTION_NEEDED;
     } else {
-      if (this.caseAdditionalSecurityFlagChanged ||
-        this.facilitiesChanged ||
-        (this.hearingFacilitiesChangesRequired && this.hearingFacilitiesChangesConfirmed)) {
+      if (AmendedChanges) {
         this.pageTitleDisplayLabel = AmendmentLabelStatus.AMENDED;
       }
     }

--- a/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.ts
@@ -137,12 +137,13 @@ export class HearingEditSummaryComponent extends RequestHearingPageFlow implemen
       if (action === ACTION.VIEW_EDIT_REASON) {
         this.hearingsService.displayValidationError = false;
         this.validationErrors = [];
-        if (!this.hasHearingRequestObjectChanged()) {
+        const hasHearingRequestObjectChanged = this.hasHearingRequestObjectChanged();
+        if (!hasHearingRequestObjectChanged) {
           this.validationErrors = [{ id: 'no-update', message: this.notUpdatedMessage }];
           window.scrollTo({ top: 0, left: 0 });
           return;
         }
-        if (this.pageVisitChangesNotConfirmed()) {
+        if (this.pageVisitChangesNotConfirmed(hasHearingRequestObjectChanged)) {
           this.hearingsService.displayValidationError = true;
           return;
         }
@@ -430,7 +431,16 @@ export class HearingEditSummaryComponent extends RequestHearingPageFlow implemen
     this.hearingsService.submitUpdatedRequestClicked = false;
   }
 
-  private pageVisitChangesNotConfirmed(): boolean {
+  private pageVisitChangesNotConfirmed(hasHearingRequestObjectChanged: boolean): boolean {
+    const reasonableAdjustmentChangeExists = this.pageVisitReasonableAdjustmentChangeExists();
+    const partiesChangeExists = this.pageVisitPartiesChangeExists();
+    const hearingWindowChangeExists = this.pageVisitHearingWindowChangeExists();
+    const nonReasonableAdjustmentChangeExists = this.pageVisitNonReasonableAdjustmentChangeExists();
+
+    if (!(reasonableAdjustmentChangeExists || partiesChangeExists || hearingWindowChangeExists) && nonReasonableAdjustmentChangeExists && hasHearingRequestObjectChanged) {
+      return false;
+    }
+
     return this.pageVisitReasonableAdjustmentChangeExists() ||
       this.pageVisitNonReasonableAdjustmentChangeExists() ||
       this.pageVisitPartiesChangeExists() ||

--- a/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.spec.ts
+++ b/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.spec.ts
@@ -417,6 +417,103 @@ describe('HearingFacilitiesComponent', () => {
     expect(component.additionalFacilities[0].showAmendedLabel).toBe(true);
   });
 
+  it('should return true if additional facilities have changed', () => {
+    component.hearingRequestMainModel = {
+      ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+      caseDetails: { ...initialState.hearings.hearingRequest.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: true },
+      hearingDetails: {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired: ['Some facility']
+      }
+    };
+    component.hearingRequestToCompareMainModel = {
+      ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+      caseDetails: { ...initialState.hearings.hearingRequest.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: true },
+      hearingDetails: {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired: ['Some facility', 'Some other facility']
+      }
+    };
+    // eslint-disable-next-line dot-notation
+    const result = component['haveUpdatesMadeToSelections']();
+    expect(result).toBe(true);
+  });
+
+  it('should return false if additional facilities have not changed', () => {
+    component.hearingRequestMainModel = {
+      ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+      caseDetails: { ...initialState.hearings.hearingRequest.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: true },
+      hearingDetails: {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired: ['Some facility']
+      }
+    };
+    component.hearingRequestToCompareMainModel = {
+      ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+      caseDetails: { ...initialState.hearings.hearingRequest.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: true },
+      hearingDetails: {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired: ['Some facility']
+      }
+    };
+
+    // eslint-disable-next-line dot-notation
+    const result = component['haveUpdatesMadeToSelections']();
+    expect(result).toBe(false);
+  });
+
+  it('should return true if caseAdditionalSecurityFlag has changed', () => {
+    component.hearingRequestMainModel = {
+      ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+      caseDetails: { ...initialState.hearings.hearingRequest.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: false },
+      hearingDetails: {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired: ['Some facility']
+      }
+    };
+    component.hearingRequestToCompareMainModel = {
+      ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+      caseDetails: { ...initialState.hearings.hearingRequest.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: true },
+      hearingDetails: {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired: ['Some facility']
+      }
+    };
+    // eslint-disable-next-line dot-notation
+    const result = component['haveUpdatesMadeToSelections']();
+    expect(result).toBe(true);
+  });
+
+  it('should return false if caseAdditionalSecurityFlag has not changed', () => {
+    component.hearingRequestMainModel = {
+      ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+      caseDetails: { ...initialState.hearings.hearingRequest.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: true },
+      hearingDetails: {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired: ['Some facility']
+      }
+    };
+    component.hearingRequestToCompareMainModel = {
+      ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+      caseDetails: { ...initialState.hearings.hearingRequest.hearingRequestMainModel.caseDetails,
+        caseAdditionalSecurityFlag: true },
+      hearingDetails: {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+        facilitiesRequired: ['Some facility']
+      }
+    };
+    // eslint-disable-next-line dot-notation
+    const result = component['haveUpdatesMadeToSelections']();
+    expect(result).toBe(false);
+  });
+
   afterEach(() => {
     fixture.destroy();
   });

--- a/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-facilities/hearing-facilities.component.ts
@@ -12,6 +12,7 @@ import { HearingsService } from '../../../services/hearings.service';
 import * as fromHearingStore from '../../../store';
 import { CaseFlagsUtils } from '../../../utils/case-flags.utils';
 import { RequestHearingPageFlow } from '../request-hearing.page.flow';
+import { HearingsUtils } from '../../../utils/hearings.utils';
 
 @Component({
   selector: 'exui-hearing-facilities',
@@ -137,7 +138,7 @@ export class HearingFacilitiesComponent extends RequestHearingPageFlow implement
     if (this.hearingCondition.mode === Mode.VIEW_EDIT) {
       if (propertiesUpdatedOnPageVisit?.hasOwnProperty('caseFlags') &&
         (propertiesUpdatedOnPageVisit?.afterPageVisit.nonReasonableAdjustmentChangesRequired)) {
-        this.hearingsService.propertiesUpdatedOnPageVisit.afterPageVisit.nonReasonableAdjustmentChangesConfirmed = true;
+        this.hearingsService.propertiesUpdatedOnPageVisit.afterPageVisit.nonReasonableAdjustmentChangesConfirmed = this.haveUpdatesMadeToSelections();
       }
       if (propertiesUpdatedOnPageVisit?.afterPageVisit?.hearingFacilitiesChangesRequired) {
         this.hearingsService.propertiesUpdatedOnPageVisit.afterPageVisit.hearingFacilitiesChangesConfirmed = true;
@@ -178,5 +179,14 @@ export class HearingFacilitiesComponent extends RequestHearingPageFlow implement
       this.nonReasonableAdjustmentFlags = CaseFlagsUtils.displayCaseFlagsGroup(this.serviceHearingValuesModel?.caseFlags?.flags,
         this.caseFlagsRefData, this.caseFlagType);
     }
+  }
+
+  private haveUpdatesMadeToSelections() {
+    const { caseAdditionalSecurityFlagChanged, facilitiesChanged } = HearingsUtils.haveAdditionalFacilitiesChanged(
+      this.hearingRequestMainModel,
+      this.hearingRequestToCompareMainModel
+    );
+
+    return caseAdditionalSecurityFlagChanged || facilitiesChanged;
   }
 }

--- a/src/hearings/utils/hearings.utils.spec.ts
+++ b/src/hearings/utils/hearings.utils.spec.ts
@@ -596,4 +596,139 @@ describe('HearingsUtils', () => {
       expect(moment(response.hearingDetails.hearingWindow.dateRangeEnd).year()).toEqual(expectedYear + 1);
     });
   });
+  it('should return true if additional facilities have changed', () => {
+    const hearingRequestMainModel = {
+      hearingDetails: { facilitiesRequired: ['facility1', 'facility2'] }
+    } as any;
+    const hearingRequestToCompareMainModel = {
+      hearingDetails: { facilitiesRequired: ['facility1'] }
+    } as any;
+
+    const { facilitiesChanged } = HearingsUtils.haveAdditionalFacilitiesChanged(
+      hearingRequestMainModel,
+      hearingRequestToCompareMainModel
+    );
+    expect(facilitiesChanged).toBe(true);
+  });
+
+  it('should return false if additional facilities have not changed', () => {
+    const hearingRequestMainModel = {
+      hearingDetails: { facilitiesRequired: ['facility1', 'facility2'] }
+    } as any;
+    const hearingRequestToCompareMainModel = {
+      hearingDetails: { facilitiesRequired: ['facility1', 'facility2'] }
+    } as any;
+
+    const { facilitiesChanged } = HearingsUtils.haveAdditionalFacilitiesChanged(
+      hearingRequestMainModel,
+      hearingRequestToCompareMainModel
+    );
+    expect(facilitiesChanged).toBe(false);
+  });
+
+  it('should return true if case additional security flag has changed', () => {
+    const hearingRequestMainModel = {
+      caseDetails: { caseAdditionalSecurityFlag: true }
+    } as any;
+    const hearingRequestToCompareMainModel = {
+      caseDetails: { caseAdditionalSecurityFlag: false }
+    } as any;
+
+    const { caseAdditionalSecurityFlagChanged } = HearingsUtils.haveAdditionalFacilitiesChanged(
+      hearingRequestMainModel,
+      hearingRequestToCompareMainModel
+    );
+    expect(caseAdditionalSecurityFlagChanged).toBe(true);
+  });
+
+  it('should return false if case additional security flag has not changed', () => {
+    const hearingRequestMainModel = {
+      caseDetails: { caseAdditionalSecurityFlag: true }
+    } as any;
+    const hearingRequestToCompareMainModel = {
+      caseDetails: { caseAdditionalSecurityFlag: true }
+    } as any;
+
+    const { caseAdditionalSecurityFlagChanged } = HearingsUtils.haveAdditionalFacilitiesChanged(
+      hearingRequestMainModel,
+      hearingRequestToCompareMainModel
+    );
+    expect(caseAdditionalSecurityFlagChanged).toBe(false);
+  });
+  it('should return true if arrays differ in elements', () => {
+    const array1 = ['a', 'b', 'c'];
+    const array2 = ['a', 'b', 'd'];
+    expect(HearingsUtils.doArraysDiffer(array1, array2)).toBe(true);
+  });
+
+  it('should return false if arrays are identical', () => {
+    const array1 = ['a', 'b', 'c'];
+    const array2 = ['a', 'b', 'c'];
+    expect(HearingsUtils.doArraysDiffer(array1, array2)).toBe(false);
+  });
+
+  it('should return true if one array is null and the other is not', () => {
+    const array1 = null;
+    const array2 = ['a', 'b', 'c'];
+    expect(HearingsUtils.doArraysDiffer(array1, array2)).toBe(true);
+  });
+
+  it('should return false if both arrays are null', () => {
+    const array1 = null;
+    const array2 = null;
+    expect(HearingsUtils.doArraysDiffer(array1, array2)).toBe(false);
+  });
+
+  it('should return true if one array is empty and the other is not', () => {
+    const array1 = [];
+    const array2 = ['a', 'b', 'c'];
+    expect(HearingsUtils.doArraysDiffer(array1, array2)).toBe(true);
+  });
+
+  it('should return false if both arrays are empty', () => {
+    const array1 = [];
+    const array2 = [];
+    expect(HearingsUtils.doArraysDiffer(array1, array2)).toBe(false);
+  });
+
+  it('should return true if arrays have same elements but in different order', () => {
+    const array1 = ['a', 'b', 'c'];
+    const array2 = ['c', 'b', 'a'];
+    expect(HearingsUtils.doArraysDiffer(array1, array2)).toBe(false);
+  });
+
+  it('should return sorted array when given an unsorted array', () => {
+    const array = ['b', 'a', 'c'];
+    // eslint-disable-next-line dot-notation
+    const result = HearingsUtils['standardiseStringArray'](array);
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should return undefined when given a null array', () => {
+    const array = null;
+    // eslint-disable-next-line dot-notation
+    const result = HearingsUtils['standardiseStringArray'](array);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when given an undefined array', () => {
+    const array = undefined;
+    // eslint-disable-next-line dot-notation
+    const result = HearingsUtils['standardiseStringArray'](array);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when given an empty array', () => {
+    const array: string[] = [];
+    // eslint-disable-next-line dot-notation
+    const result = HearingsUtils['standardiseStringArray'](array);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return sorted array when given an already sorted array', () => {
+    const array = ['a', 'b', 'c'];
+    // eslint-disable-next-line dot-notation
+    const result = HearingsUtils['standardiseStringArray'](array);
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
 });

--- a/src/hearings/utils/hearings.utils.ts
+++ b/src/hearings/utils/hearings.utils.ts
@@ -256,4 +256,29 @@ export class HearingsUtils {
       HearingsUtils.modifyHearingDetailsYear(input?.hearingDetails?.hearingWindow);
     }
   }
+
+  public static doArraysDiffer(array: string[], arrayToCompare: string[]): boolean {
+    return !_.isEqual(this.standardiseStringArray(array), this.standardiseStringArray(arrayToCompare));
+  }
+
+  private static standardiseStringArray(array: string[] | null | undefined): string[] | undefined {
+    return array && array.length > 0 ? [...array].sort() : undefined;
+  }
+
+  public static haveAdditionalFacilitiesChanged(
+    hearingRequestMainModel: HearingRequestMainModel,
+    hearingRequestToCompareMainModel: HearingRequestMainModel
+  ): { caseAdditionalSecurityFlagChanged: boolean; facilitiesChanged: boolean } {
+    const caseAdditionalSecurityFlagChanged = !_.isEqual(
+      hearingRequestMainModel.caseDetails?.caseAdditionalSecurityFlag,
+      hearingRequestToCompareMainModel.caseDetails?.caseAdditionalSecurityFlag
+    );
+
+    const facilitiesChanged = this.doArraysDiffer(
+      hearingRequestMainModel.hearingDetails?.facilitiesRequired,
+      hearingRequestToCompareMainModel.hearingDetails?.facilitiesRequired
+    );
+
+    return { caseAdditionalSecurityFlagChanged, facilitiesChanged };
+  }
 }

--- a/src/hearings/utils/hearings.utils.ts
+++ b/src/hearings/utils/hearings.utils.ts
@@ -262,7 +262,9 @@ export class HearingsUtils {
   }
 
   private static standardiseStringArray(array: string[] | null | undefined): string[] | undefined {
-    return array && array.length > 0 ? [...array].sort() : undefined;
+    return array && array.length > 0 ? [...array].sort((a, b) => {
+      return a > b ? 1 : (a === b ? 0 : -1);
+    }) : undefined;
   }
 
   public static haveAdditionalFacilitiesChanged(

--- a/test_codecept/ngIntegration/tests/features/hearings/viewEditHearings/editHearingUpdateLabels.feature
+++ b/test_codecept/ngIntegration/tests/features/hearings/viewEditHearings/editHearingUpdateLabels.feature
@@ -236,7 +236,7 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
     Then I validate edit hearing section heading labels
       | Heading                                    | Label         |
       | Hearing requirements                       | AMENDED       |
-      | Additional facilities                      |               |
+      | Additional facilities                      | ACTION NEEDED |
       | Participant attendance                     | AMENDED       |
       | Length, date and priority level of hearing | ACTION NEEDED |
         # end of Additional facilities
@@ -249,11 +249,11 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
     When I click continue in hearing workflow
     Then I validate Edit hearing page displayed
     Then I validate edit hearing section heading labels
-      | Heading                                    | Label   |
-      | Hearing requirements                       | AMENDED |
-      | Additional facilities                      |         |
-      | Participant attendance                     | AMENDED |
-      | Length, date and priority level of hearing | AMENDED |
+      | Heading                                    | Label         |
+      | Hearing requirements                       | AMENDED       |
+      | Additional facilities                      | ACTION NEEDED |
+      | Participant attendance                     | AMENDED       |
+      | Length, date and priority level of hearing | AMENDED       |
         # end of Length, date and priority level of hearing
 
 
@@ -373,7 +373,7 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
     Then I validate edit hearing section heading labels
       | Heading                                    | Label         |
       | Hearing requirements                       | AMENDED       |
-      | Additional facilities                      |               |
+      | Additional facilities                      | ACTION NEEDED |
       | Participant attendance                     | AMENDED       |
       | Length, date and priority level of hearing | ACTION NEEDED |
         # end of Additional facilities
@@ -389,11 +389,11 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
       When I click continue in hearing workflow
       Then I validate Edit hearing page displayed
       Then I validate edit hearing section heading labels
-          | Heading                                    | Label   |
-          | Hearing requirements                       | AMENDED |
-          | Additional facilities                      |         |
-          | Participant attendance                     | AMENDED |
-          | Length, date and priority level of hearing | AMENDED |
+          | Heading                                    | Label         |
+          | Hearing requirements                       | AMENDED       |
+          | Additional facilities                      | ACTION NEEDED |
+          | Participant attendance                     | AMENDED       |
+          | Length, date and priority level of hearing | AMENDED       |
       # end of Length, date and priority level of hearing
 
 

--- a/test_codecept/ngIntegration/tests/features/hearings/viewEditHearings/editHearingUpdateLabels.feature
+++ b/test_codecept/ngIntegration/tests/features/hearings/viewEditHearings/editHearingUpdateLabels.feature
@@ -236,7 +236,7 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
     Then I validate edit hearing section heading labels
       | Heading                                    | Label         |
       | Hearing requirements                       | AMENDED       |
-      | Additional facilities                      | AMENDED       |
+      | Additional facilities                      |               |
       | Participant attendance                     | AMENDED       |
       | Length, date and priority level of hearing | ACTION NEEDED |
         # end of Additional facilities
@@ -251,7 +251,7 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
     Then I validate edit hearing section heading labels
       | Heading                                    | Label   |
       | Hearing requirements                       | AMENDED |
-      | Additional facilities                      | AMENDED |
+      | Additional facilities                      |         |
       | Participant attendance                     | AMENDED |
       | Length, date and priority level of hearing | AMENDED |
         # end of Length, date and priority level of hearing
@@ -373,7 +373,7 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
     Then I validate edit hearing section heading labels
       | Heading                                    | Label         |
       | Hearing requirements                       | AMENDED       |
-      | Additional facilities                      | AMENDED       |
+      | Additional facilities                      |               |
       | Participant attendance                     | AMENDED       |
       | Length, date and priority level of hearing | ACTION NEEDED |
         # end of Additional facilities
@@ -391,7 +391,7 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
       Then I validate edit hearing section heading labels
           | Heading                                    | Label   |
           | Hearing requirements                       | AMENDED |
-          | Additional facilities                      | AMENDED |
+          | Additional facilities                      |         |
           | Participant attendance                     | AMENDED |
           | Length, date and priority level of hearing | AMENDED |
       # end of Length, date and priority level of hearing


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2917

### Change description

A change we have made in EXUI-2321 has exposed a new bug for CR84.  When a new case flag has been created and accepted in the hearing edit, the hearing request is being allowed to progress.  However, if the only action is to accept the flag, and no changes to the request have been made, then this now gets a validation warning message to state no changes have been made.   This change is to remove the amended label for the section header, as this is misleading to the user. 


### Testing done

This has been tested with Doug Rice the QA and has been through a number of scenarios. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
