### PR TITLE
pointing to correct data source and removing redundant amended labels.

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.html
+++ b/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.html
@@ -48,7 +48,7 @@
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             <h3 class="govuk-fieldset__heading">
               {{ 'Does the hearing need to take place on a specific date?' | rpxTranslate }}
-              <exui-amendment-label id="hearing-specific-dates-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired && (dateRangeStartChanged || dateRangeEndChanged || firstDateTimeMustBeChanged)"
+              <exui-amendment-label id="hearing-specific-dates-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired"
                 [displayLabel]="amendmentLabelEnum.ACTION_NEEDED">
               </exui-amendment-label>
             </h3>
@@ -74,9 +74,6 @@
               <div class="govuk-form-group">
                 <div class="govuk-!-margin-right-1 first-hearing-date">
                   <xuilib-gov-uk-date [config]="firstHearingDate" [formGroup]="firstHearingFormGroup" [errorMessage]="firstDateOfHearingError"></xuilib-gov-uk-date>
-                  <exui-amendment-label id="first-date-amendment-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired && firstDateTimeMustBeChanged"
-                      [displayLabel]="amendmentLabelEnum.AMENDED">
-                  </exui-amendment-label>
                 </div>
               </div>
             </div>
@@ -93,15 +90,9 @@
                 </span>
                 <div class="govuk-form-group">
                   <xuilib-gov-uk-date [config]="earliestHearingDate" [formGroup]="earliestHearingFormGroup" [errorMessage]="earliestDateOfHearingError"></xuilib-gov-uk-date>
-                  <exui-amendment-label id="earliest-hearing-date-amendment-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired && dateRangeStartChanged"
-                     [displayLabel]="amendmentLabelEnum.AMENDED">
-                  </exui-amendment-label>
                 </div>
                 <div class="govuk-form-group">
                   <xuilib-gov-uk-date [config]="latestHearingDate" [formGroup]="latestHearingFormGroup" [errorMessage]="latestDateOfHearingError"></xuilib-gov-uk-date>
-                  <exui-amendment-label id="latest-hearing-date-amendment-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired && dateRangeEndChanged"
-                     [displayLabel]="amendmentLabelEnum.AMENDED">
-                  </exui-amendment-label>
                 </div>
               </div>
             </div>
@@ -116,9 +107,6 @@
         <fieldset class="govuk-fieldset" id="hearing-priority">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             <h3 class="govuk-fieldset__heading">{{ 'What is the priority of this hearing?' | rpxTranslate }}
-            <exui-amendment-label id="hearing-priority-amendment-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired && priorityChanged"
-                                  [displayLabel]="amendmentLabelEnum.AMENDED">
-            </exui-amendment-label>
             </h3>
           </legend>
           <span class="govuk-error-message" *ngIf="hearingPriorityError">

--- a/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.spec.ts
+++ b/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.spec.ts
@@ -18,7 +18,6 @@ import { ValidatorsUtils } from '../../../utils/validators.utils';
 import { HearingTimingComponent } from './hearing-timing.component';
 import { PartyDetailsModel } from '../../../models/partyDetails.model';
 import { SourceOfData } from '../../../../../api/hearings/models/hearings.enum';
-import { HearingsUtils } from '../../../utils/hearings.utils';
 
 @Component({
   selector: 'exui-hearing-parties-title',
@@ -26,6 +25,57 @@ import { HearingsUtils } from '../../../utils/hearings.utils';
 })
 class MockHearingPartiesComponent {
   @Input() public error: ErrorMessage;
+}
+
+const setDataHearingRequestMainModel = {
+  ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+  hearingDetails: {
+    duration: 180,
+    hearingWindow: { dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' },
+    hearingPriorityType: 'standard',
+    hearingType: '',
+    hearingLocations: [],
+    panelRequirements: undefined,
+    autolistFlag: false,
+    amendReasonCodes: [],
+    hearingChannels: [],
+    listingAutoChangeReasonCode: ''
+  },
+  partyDetails: [{
+    unavailabilityRanges: [{
+      unavailableFromDate: '2024-02-01',
+      unavailableToDate: '2024-02-02',
+      unavailabilityType: UnavailabilityType.AM
+    }],
+    partyID: '',
+    partyType: PartyType.IND,
+    partyRole: ''
+  }]
+};
+
+const setDataServiceHearingValuesModel = {
+  ...initialState.hearings.hearingValues.serviceHearingValuesModel,
+  parties: [{
+    partyID: 'party1',
+    partyType: PartyType.IND,
+    partyRole: 'partyRole',
+    unavailabilityRanges: [{
+      unavailableFromDate: '2024-01-01',
+      unavailableToDate: '2024-01-02',
+      unavailabilityType: UnavailabilityType.PM
+    }]
+  }],
+  hearingPriorityType: 'high',
+  duration: 120,
+  hearingWindow: { dateRangeStart: '2024-01-01', dateRangeEnd: '2024-01-02' }
+};
+
+function getHearingRequestMainModel() {
+  return JSON.parse(JSON.stringify(setDataHearingRequestMainModel));
+}
+
+function getServiceHearingValuesModel() {
+  return JSON.parse(JSON.stringify(setDataServiceHearingValuesModel));
 }
 
 describe('HearingTimingComponent', () => {
@@ -698,174 +748,164 @@ describe('HearingTimingComponent', () => {
     expect(component.sourceOfData).toBe(SourceOfData.HEARING_REQUEST_MAIN_MODEL);
   });
 
-  it('should set data items from serviceHearingValuesModel when sourceOFData is SERVICE_HEARING_VALUES', () => {
+  it('should set unavailabilityDateList from serviceHearingValuesModel when sourceOFData is SERVICE_HEARING_VALUES', () => {
     component.sourceOfData = SourceOfData.SERVICE_HEARING_VALUES;
 
-    component.serviceHearingValuesModel = {
-      ...component.serviceHearingValuesModel,
-      parties: [{
-        partyID: 'party1',
-        partyType: PartyType.IND,
-        partyRole: 'partyRole',
-        unavailabilityRanges: [{
-          unavailableFromDate: '2024-01-01',
-          unavailableToDate: '2024-01-02',
-          unavailabilityType: UnavailabilityType.PM
-        }]
-      }],
-      hearingPriorityType: 'High',
-      duration: 120,
-      hearingWindow: { dateRangeStart: '2024-01-01', dateRangeEnd: '2024-01-02' }
-    };
+    component.hearingRequestMainModel = getHearingRequestMainModel();
 
-    component.prepareHearingRequestData();
+    component.serviceHearingValuesModel = getServiceHearingValuesModel();
 
     component.setDataItems();
 
-    expect(component.duration).toBe(60);
-    expect(component.hearingWindow).toEqual({ dateRangeStart: '2024-01-01', dateRangeEnd: '2024-01-02' });
-    expect(component.hearingPriorityType).toBe('High');
+    component.prepareHearingRequestData();
+
+    expect(component.duration).toBe(180);
+    expect(component.hearingWindow).toEqual({ dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' });
+    expect(component.hearingPriorityType).toBe('standard');
     expect(component.unavailabilityDateList).toEqual([{ unavailableFromDate: '2024-01-01', unavailableToDate: '2024-01-02', unavailabilityType: UnavailabilityType.PM }]);
   });
 
   it('should set data items from hearingRequestMainModel when sourceOFData is HEARING_REQUEST_MAIN_MODEL', () => {
     component.sourceOfData = SourceOfData.HEARING_REQUEST_MAIN_MODEL;
-    component.hearingRequestMainModel = {
-      ...component.hearingRequestMainModel,
-      hearingDetails: {
-        duration: 180,
-        hearingWindow: { dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' },
-        hearingPriorityType: 'Medium',
-        hearingType: '',
-        hearingLocations: [],
-        panelRequirements: undefined,
-        autolistFlag: false,
-        amendReasonCodes: [],
-        hearingChannels: [],
-        listingAutoChangeReasonCode: ''
-      },
-      partyDetails: [{
-        unavailabilityRanges: [{
-          unavailableFromDate: '2024-02-01',
-          unavailableToDate: '2024-02-02',
-          unavailabilityType: UnavailabilityType.AM
-        }],
-        partyID: '',
-        partyType: PartyType.IND,
-        partyRole: ''
-      }]
-    };
+
+    component.hearingRequestMainModel = getHearingRequestMainModel();
+
+    component.serviceHearingValuesModel = getServiceHearingValuesModel();
 
     component.setDataItems();
 
     expect(component.duration).toBe(180);
     expect(component.hearingWindow).toEqual({ dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' });
-    expect(component.hearingPriorityType).toBe('Medium');
+    expect(component.hearingPriorityType).toBe('standard');
     expect(component.unavailabilityDateList).toEqual([{ unavailableFromDate: '2024-02-01', unavailableToDate: '2024-02-02', unavailabilityType: UnavailabilityType.AM }]);
   });
 
   it('should set duration from SHV when absent from is HEARING_REQUEST_MAIN_MODEL', () => {
     component.sourceOfData = SourceOfData.HEARING_REQUEST_MAIN_MODEL;
-    component.hearingRequestMainModel = {
-      ...component.hearingRequestMainModel,
-      hearingDetails: {
-        duration: undefined,
-        hearingWindow: { dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' },
-        hearingPriorityType: 'Medium',
-        hearingType: '',
-        hearingLocations: [],
-        panelRequirements: undefined,
-        autolistFlag: false,
-        amendReasonCodes: [],
-        hearingChannels: [],
-        listingAutoChangeReasonCode: ''
-      },
-      partyDetails: [{
-        unavailabilityRanges: [{
-          unavailableFromDate: '2024-02-01',
-          unavailableToDate: '2024-02-02',
-          unavailabilityType: UnavailabilityType.AM
-        }],
-        partyID: '',
-        partyType: PartyType.IND,
-        partyRole: ''
-      }]
-    };
-    component.serviceHearingValuesModel = {
-      ...component.serviceHearingValuesModel,
-      parties: [{
-        partyID: 'party1',
-        partyType: PartyType.IND,
-        partyRole: 'partyRole',
-        unavailabilityRanges: [{
-          unavailableFromDate: '2024-01-01',
-          unavailableToDate: '2024-01-02',
-          unavailabilityType: UnavailabilityType.PM
-        }]
-      }],
-      hearingPriorityType: 'High',
-      duration: 120,
-      hearingWindow: { dateRangeStart: '2024-01-01', dateRangeEnd: '2024-01-02' }
-    };
+
+    component.hearingRequestMainModel = getHearingRequestMainModel();
+
+    component.hearingRequestMainModel.hearingDetails.duration = undefined;
+
+    component.serviceHearingValuesModel = getServiceHearingValuesModel();
 
     component.setDataItems();
 
     expect(component.duration).toBe(120);
     expect(component.hearingWindow).toEqual({ dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' });
-    expect(component.hearingPriorityType).toBe('Medium');
+    expect(component.hearingPriorityType).toBe('standard');
     expect(component.unavailabilityDateList).toEqual([{ unavailableFromDate: '2024-02-01', unavailableToDate: '2024-02-02', unavailabilityType: UnavailabilityType.AM }]);
   });
 
   it('should set duration from SHV when duration is 0 from HEARING_REQUEST_MAIN_MODEL', () => {
     component.sourceOfData = SourceOfData.HEARING_REQUEST_MAIN_MODEL;
-    component.hearingRequestMainModel = {
-      ...component.hearingRequestMainModel,
-      hearingDetails: {
-        duration: 0,
-        hearingWindow: { dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' },
-        hearingPriorityType: 'Medium',
-        hearingType: '',
-        hearingLocations: [],
-        panelRequirements: undefined,
-        autolistFlag: false,
-        amendReasonCodes: [],
-        hearingChannels: [],
-        listingAutoChangeReasonCode: ''
-      },
-      partyDetails: [{
-        unavailabilityRanges: [{
-          unavailableFromDate: '2024-02-01',
-          unavailableToDate: '2024-02-02',
-          unavailabilityType: UnavailabilityType.AM
-        }],
-        partyID: '',
-        partyType: PartyType.IND,
-        partyRole: ''
-      }]
-    };
-    component.serviceHearingValuesModel = {
-      ...component.serviceHearingValuesModel,
-      parties: [{
-        partyID: 'party1',
-        partyType: PartyType.IND,
-        partyRole: 'partyRole',
-        unavailabilityRanges: [{
-          unavailableFromDate: '2024-01-01',
-          unavailableToDate: '2024-01-02',
-          unavailabilityType: UnavailabilityType.PM
-        }]
-      }],
-      hearingPriorityType: 'High',
-      duration: 120,
-      hearingWindow: { dateRangeStart: '2024-01-01', dateRangeEnd: '2024-01-02' }
-    };
+
+    component.hearingRequestMainModel = getHearingRequestMainModel();
+
+    component.hearingRequestMainModel.hearingDetails.duration = 0;
+
+    component.serviceHearingValuesModel = getServiceHearingValuesModel();
 
     component.setDataItems();
 
     expect(component.duration).toBe(120);
     expect(component.hearingWindow).toEqual({ dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' });
-    expect(component.hearingPriorityType).toBe('Medium');
+    expect(component.hearingPriorityType).toBe('standard');
     expect(component.unavailabilityDateList).toEqual([{ unavailableFromDate: '2024-02-01', unavailableToDate: '2024-02-02', unavailabilityType: UnavailabilityType.AM }]);
+  });
+
+  describe('setDuration', () => {
+    it('should set duration from hearingRequestMainModel', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      (component as any).setDuration();
+      expect(component.duration).toBe(180);
+    });
+
+    it('should set duration from serviceHearingValuesModel if not in hearingRequestMainModel', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.hearingRequestMainModel.hearingDetails.duration = null;
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      (component as any).setDuration();
+      expect(component.duration).toBe(120);
+    });
+
+    it('should not set duration if not available in both models', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.hearingRequestMainModel.hearingDetails.duration = null;
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      component.serviceHearingValuesModel.duration = null;
+      (component as any).setDuration();
+      expect(component.duration).toBeNull();
+    });
+  });
+
+  describe('setHearingWindow', () => {
+    it('should set hearingWindow from hearingRequestMainModel', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      (component as any).setHearingWindow();
+      expect(component.hearingWindow).toEqual({ dateRangeStart: '2024-02-01', dateRangeEnd: '2024-02-02' });
+    });
+
+    it('should set hearingWindow from serviceHearingValuesModel if not in hearingRequestMainModel', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.hearingRequestMainModel.hearingDetails.hearingWindow = null;
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      (component as any).setHearingWindow();
+      expect(component.hearingWindow).toEqual({ dateRangeStart: '2024-01-01', dateRangeEnd: '2024-01-02' });
+    });
+
+    it('should not set hearingWindow if not available in both models', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.hearingRequestMainModel.hearingDetails.hearingWindow = null;
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      component.serviceHearingValuesModel.hearingWindow = null;
+      (component as any).setHearingWindow();
+      expect(component.hearingWindow).toBeNull();
+    });
+  });
+  describe('setHearingPriorityType', () => {
+    it('should set hearingPriorityType from hearingRequestMainModel', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      (component as any).setHearingPriorityType();
+      expect(component.hearingPriorityType).toBe('standard');
+    });
+
+    it('should set hearingPriorityType from serviceHearingValuesModel if not in hearingRequestMainModel', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.hearingRequestMainModel.hearingDetails.hearingPriorityType = null;
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      (component as any).setHearingPriorityType();
+      expect(component.hearingPriorityType).toBe('high');
+    });
+
+    it('should not set hearingPriorityType if not available in both models', () => {
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.hearingRequestMainModel.hearingDetails.hearingPriorityType = null;
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      component.serviceHearingValuesModel.hearingPriorityType = null;
+      (component as any).setHearingPriorityType();
+      expect(component.hearingPriorityType).toBeNull();
+    });
+  });
+  describe('setUnavailableDatesList', () => {
+    it('should set unavailabilityDateList from serviceHearingValuesModel if sourceOfData is SERVICE_HEARING_VALUES', () => {
+      component.sourceOfData = SourceOfData.SERVICE_HEARING_VALUES;
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      (component as any).setUnavailableDatesList();
+      expect(component.unavailabilityDateList).toEqual([{ unavailableFromDate: '2024-01-01', unavailableToDate: '2024-01-02', unavailabilityType: UnavailabilityType.PM }]);
+    });
+
+    it('should set unavailabilityDateList from hearingRequestMainModel if sourceOfData is HEARING_REQUEST_MAIN_MODEL', () => {
+      component.sourceOfData = SourceOfData.HEARING_REQUEST_MAIN_MODEL;
+      component.hearingRequestMainModel = getHearingRequestMainModel();
+      component.serviceHearingValuesModel = getServiceHearingValuesModel();
+      (component as any).setUnavailableDatesList();
+      expect(component.unavailabilityDateList).toEqual([{ unavailableFromDate: '2024-02-01', unavailableToDate: '2024-02-02', unavailabilityType: UnavailabilityType.AM }]);
+    });
   });
 
   it('should set hearingUnavailabilityDatesChanged to true when hearingUnavailabilityDatesChanged is true and hearingUnavailabilityDatesConfirmed is false', () => {
@@ -887,38 +927,6 @@ describe('HearingTimingComponent', () => {
     component.setAmendmentFlags();
 
     expect(component.hearingUnavailabilityDatesChanged).toBe(true);
-  });
-
-  it('should set dateRangeStartChanged to true when dateRangeStartChanged is true', () => {
-    spyOn(HearingsUtils, 'hasDateChanged').and.returnValue(true);
-
-    component.setAmendmentFlags();
-
-    expect(component.dateRangeStartChanged).toBe(true);
-  });
-
-  it('should set dateRangeEndChanged to true when dateRangeEndChanged is true', () => {
-    spyOn(HearingsUtils, 'hasDateChanged').and.returnValue(true);
-
-    component.setAmendmentFlags();
-
-    expect(component.dateRangeEndChanged).toBe(true);
-  });
-
-  it('should set firstDateTimeMustBeChanged to true when firstDateTimeMustBeChanged is true', () => {
-    spyOn(HearingsUtils, 'hasDateChanged').and.returnValue(true);
-
-    component.setAmendmentFlags();
-
-    expect(component.firstDateTimeMustBeChanged).toBe(true);
-  });
-
-  it('should set priorityChanged to true when priorityChanged is true', () => {
-    spyOn(HearingsUtils, 'hasHearingPriorityChanged').and.returnValue(true);
-
-    component.setAmendmentFlags();
-
-    expect(component.priorityChanged).toBe(true);
   });
 
   describe('HearingTimingComponent', () => {
@@ -1053,3 +1061,4 @@ describe('HearingTimingComponent', () => {
     fixture.destroy();
   });
 });
+

--- a/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.ts
@@ -50,10 +50,6 @@ export class HearingTimingComponent extends RequestHearingPageFlow implements On
   public hearingWindowChangesRequired: boolean;
   public hearingWindowChangesConfirmed: boolean;
   public hearingUnavailabilityDatesChanged: boolean;
-  public dateRangeStartChanged: boolean;
-  public dateRangeEndChanged: boolean;
-  public firstDateTimeMustBeChanged: boolean;
-  public priorityChanged: boolean;
   public amendmentLabelEnum = AmendmentLabelStatus;
   public duration: number;
   public hearingWindow: HearingWindowModel;
@@ -116,22 +112,34 @@ export class HearingTimingComponent extends RequestHearingPageFlow implements On
   }
 
   public setDataItems() {
-    // it is not a requirement to tell the user if the default value of the hearing duration has been updated.
-    if (this.hearingRequestMainModel.hearingDetails.duration && this.hearingRequestMainModel.hearingDetails.duration > 0) {
-      this.duration = this.hearingRequestMainModel.hearingDetails.duration;
-    } else {
-      if (this.serviceHearingValuesModel.duration) {
-        this.duration = this.serviceHearingValuesModel.duration;
-      }
-    }
+    this.setDuration();
+    this.setHearingWindow();
+    this.setHearingPriorityType();
+    this.setUnavailableDatesList();
+  }
 
+  private setDuration() {
+    this.duration = this.hearingRequestMainModel.hearingDetails?.duration > 0
+      ? this.hearingRequestMainModel.hearingDetails.duration
+      : this.serviceHearingValuesModel.duration || null;
+  }
+
+  private setHearingWindow() {
+    this.hearingWindow = this.hearingRequestMainModel.hearingDetails?.hearingWindow
+      || this.serviceHearingValuesModel?.hearingWindow
+      || null;
+  }
+
+  private setHearingPriorityType(){
+    this.hearingPriorityType = this.hearingRequestMainModel.hearingDetails?.hearingPriorityType
+      || this.serviceHearingValuesModel?.hearingPriorityType
+      || null;
+  }
+
+  private setUnavailableDatesList() {
     if (this.sourceOfData === SourceOfData.SERVICE_HEARING_VALUES) {
-      this.hearingWindow = this.serviceHearingValuesModel.hearingWindow;
-      this.hearingPriorityType = this.serviceHearingValuesModel.hearingPriorityType;
       this.unavailabilityDateList = this.serviceHearingValuesModel.parties.flatMap((party) => party.unavailabilityRanges);
     } else {
-      this.hearingWindow = this.hearingRequestMainModel.hearingDetails.hearingWindow;
-      this.hearingPriorityType = this.hearingRequestMainModel.hearingDetails.hearingPriorityType;
       this.unavailabilityDateList = this.hearingRequestMainModel.partyDetails.flatMap((party) => party.unavailabilityRanges);
     }
   }
@@ -139,10 +147,6 @@ export class HearingTimingComponent extends RequestHearingPageFlow implements On
   public setAmendmentFlags() {
     this.hearingUnavailabilityDatesChanged = this.hearingsService.propertiesUpdatedOnPageVisit?.afterPageVisit?.hearingUnavailabilityDatesChanged &&
       !this.hearingsService.propertiesUpdatedOnPageVisit?.afterPageVisit?.hearingUnavailabilityDatesConfirmed;
-    this.dateRangeStartChanged = HearingsUtils.hasDateChanged(this.hearingRequestMainModel.hearingDetails.hearingWindow?.dateRangeStart, this.serviceHearingValuesModel.hearingWindow?.dateRangeStart);
-    this.dateRangeEndChanged = HearingsUtils.hasDateChanged(this.hearingRequestMainModel.hearingDetails.hearingWindow?.dateRangeEnd, this.serviceHearingValuesModel.hearingWindow?.dateRangeEnd);
-    this.firstDateTimeMustBeChanged = HearingsUtils.hasDateChanged(this.hearingRequestMainModel.hearingDetails.hearingWindow?.firstDateTimeMustBe, this.serviceHearingValuesModel.hearingWindow?.firstDateTimeMustBe);
-    this.priorityChanged = HearingsUtils.hasHearingPriorityChanged(this.hearingRequestMainModel.hearingDetails.hearingPriorityType, this.serviceHearingValuesModel.hearingPriorityType);
   }
 
   public getFormData(durationInput: number, hearingWindowInput: HearingWindowModel, priorityInput: string): void {

--- a/test_codecept/e2e/features/step_definitions/hearings/hearingsCommon.steps.js
+++ b/test_codecept/e2e/features/step_definitions/hearings/hearingsCommon.steps.js
@@ -108,28 +108,9 @@ Then('In additional facilities page, I see case flags displayed for parties', as
   }
 });
 
-Then('In Length, date and priority level of hearing page, I see ACTION NEEDED label displayed for The first date of the hearing must be', async function () {
+Then('In Length, date and priority level of hearing page, I see ACTION NEEDED label displayed for Does the hearing need to take place on a specific date?', async function () {
   const page = getPageObject('Length, date and priority level of hearing');
-  expect(await page.isActionNeededLabelDisplayedForField('The first date of the hearing must be')).to.be.true;
+  expect(await page.isActionNeededLabelDisplayedForField('Does the hearing need to take place on a specific date?')).to.be.true;
 });
 
-Then('In Length, date and priority level of hearing page, I see AMENDED label displayed for Length of hearing', async function () {
-  const page = getPageObject('Length, date and priority level of hearing');
-  expect(await page.isActionNeededLabelDisplayedForField('Length of hearing')).to.be.true;
-});
-
-Then('In Length, date and priority level of hearing page, I see AMENDED label displayed for the latest end date', async function () {
-  const page = getPageObject('Length, date and priority level of hearing');
-  expect(await page.isActionNeededLabelDisplayedForField('Latest end date')).to.be.true;
-});
-
-Then('In Length, date and priority level of hearing page, I see no label displayed for the earliest end date', async function () {
-  const page = getPageObject('Length, date and priority level of hearing');
-  expect(await page.isActionNeededLabelDisplayedForField('Earliest start date')).to.be.false;
-});
-
-Then('In Length, date and priority level of hearing page, I dont see ACTION NEEDED label displayed for The first date of the hearing must be', async function () {
-  const page = getPageObject('Length, date and priority level of hearing');
-  expect(await page.isActionNeededLabelDisplayedForField('The first date of the hearing must be')).to.be.false;
-});
 

--- a/test_codecept/ngIntegration/tests/features/hearings/viewEditHearings/editHearingUpdateLabels.feature
+++ b/test_codecept/ngIntegration/tests/features/hearings/viewEditHearings/editHearingUpdateLabels.feature
@@ -244,7 +244,7 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
         # Accept Length, date and priority level of hearing
     When In view or edit hearing page, I click change link for field "Length of hearing"
     Then I am on hearings workflow page "Length, date and priority level of hearing"
-    Then In Length, date and priority level of hearing page, I see ACTION NEEDED label displayed for The first date of the hearing must be
+    Then In Length, date and priority level of hearing page, I see ACTION NEEDED label displayed for Does the hearing need to take place on a specific date?
 
     When I click continue in hearing workflow
     Then I validate Edit hearing page displayed
@@ -383,9 +383,8 @@ Feature: Hearings CR84: Semi automatic and automatic update labels EUI-8905
       When In view or edit hearing page, I click change link for field "Length of hearing"
       Then I am on hearings workflow page "Length, date and priority level of hearing"
       # Then debug sleep minutes 4
-#      Then In Length, date and priority level of hearing page, I see AMENDED label displayed for Length of hearing
-      Then In Length, date and priority level of hearing page, I see AMENDED label displayed for the latest end date
-      Then In Length, date and priority level of hearing page, I see no label displayed for the earliest end date
+      Then In Length, date and priority level of hearing page, I see ACTION NEEDED label displayed for Does the hearing need to take place on a specific date?
+
       When I click continue in hearing workflow
       Then I validate Edit hearing page displayed
       Then I validate edit hearing section heading labels


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2956

### Change description

In the investigation of EXUI-2706, it was found that we were incorrectly using the shv values for the priority and hearing window, where a change to the unavailability dates (the only data for this section that creates an action required) was being amended. This change ensures that hmc values are used in the first instance.  Also, some of the other data items on the page had redundant amended labels and data items for the setting of these labels.  These have also been removed. 

### Testing done

This has been walked through locally with the QA prior to checking in. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - No
