### PR TITLE
EXUI-2252 add otherReasonableAdjustmentDetails automatically

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.spec.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.spec.ts
@@ -683,7 +683,8 @@ describe('HearingEditSummaryComponent', () => {
           vulnerableFlag: true,
           vulnerabilityDetails: 'New vulnerability details',
           hearingChannelEmail: ['New email'],
-          hearingChannelPhone: ['New Phone']
+          hearingChannelPhone: ['New Phone'],
+          otherReasonableAdjustmentDetails: 'other reasonable adjustments'
         },
         unavailabilityDOW: null,
         unavailabilityRanges: [
@@ -724,7 +725,8 @@ describe('HearingEditSummaryComponent', () => {
           vulnerableFlag: true,
           vulnerabilityDetails: 'New vulnerability details',
           hearingChannelEmail: ['New email'],
-          hearingChannelPhone: ['New Phone']
+          hearingChannelPhone: ['New Phone'],
+          otherReasonableAdjustmentDetails: 'other reasonable adjustments'
         },
         unavailabilityDOW: null,
         unavailabilityRanges: [

--- a/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/hearing-edit-summary.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { FeatureToggleService } from '@hmcts/rpx-xui-common-lib';
 import { Store } from '@ngrx/store';
 import * as _ from 'lodash';
+import { cloneDeep } from 'lodash';
 import * as moment from 'moment';
 import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -35,7 +36,6 @@ import * as fromHearingStore from '../../../store';
 import { HearingsUtils } from '../../../utils/hearings.utils';
 import { RequestHearingPageFlow } from '../request-hearing.page.flow';
 import { UnavailabilityRangeModel } from '../../../models/unavailabilityRange.model';
-import { cloneDeep } from 'lodash';
 
 @Component({
   selector: 'exui-hearing-edit-summary',
@@ -426,7 +426,8 @@ export class HearingEditSummaryComponent extends RequestHearingPageFlow implemen
                 vulnerableFlag: this.compareAndUpdateServiceHearingValues(party.individualDetails?.vulnerableFlag, serviceParty.individualDetails?.vulnerableFlag, AutoUpdateMode.PARTY),
                 vulnerabilityDetails: this.compareAndUpdateServiceHearingValues(party.individualDetails?.vulnerabilityDetails, serviceParty.individualDetails?.vulnerabilityDetails, AutoUpdateMode.PARTY),
                 hearingChannelEmail: this.compareAndUpdateServiceHearingValues(party.individualDetails?.hearingChannelEmail, serviceParty.individualDetails?.hearingChannelEmail, AutoUpdateMode.PARTY),
-                hearingChannelPhone: this.compareAndUpdateServiceHearingValues(party.individualDetails?.hearingChannelPhone, serviceParty.individualDetails?.hearingChannelPhone, AutoUpdateMode.PARTY)
+                hearingChannelPhone: this.compareAndUpdateServiceHearingValues(party.individualDetails?.hearingChannelPhone, serviceParty.individualDetails?.hearingChannelPhone, AutoUpdateMode.PARTY),
+                otherReasonableAdjustmentDetails: this.compareAndUpdateServiceHearingValues(party.individualDetails.otherReasonableAdjustmentDetails, serviceParty.individualDetails?.otherReasonableAdjustmentDetails, AutoUpdateMode.PARTY)
               },
               unavailabilityDOW: this.compareAndUpdateServiceHearingValues(party?.unavailabilityDOW, serviceParty?.unavailabilityDOW, AutoUpdateMode.WITHIN_PAGE, WithinPagePropertiesEnum.PARTIES)
             });


### PR DESCRIPTION
…pdated fields.

### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2252

### Change description

otherReasonableAdjustmentDetails data is not being updated.  The design has been queried and it has been agreed that this data item can be updated automatically, not updated after a page visit. 

### Testing done

The updated language interpreter data has been seen to be updated by the addition of the automatic addition of this data. 

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
