### PR TITLE
EXUI-3244 - Dont reset the store if cr84 is enabled

### DIFF
--- a/src/cases/components/case-hearings-list/case-hearings-list.component.ts
+++ b/src/cases/components/case-hearings-list/case-hearings-list.component.ts
@@ -123,7 +123,6 @@ export class CaseHearingsListComponent implements OnInit {
     this.hearingStore.dispatch(new fromHearingStore.SaveHearingConditions(hearingCondition));
     // If hearing amendments enabled in Launch Darkly, then load the Service Hearing Values to get the latest
     if (this.isHearingAmendmentsEnabled) {
-      this.hearingStore.dispatch(new fromHearingStore.ResetHearingValues());
       this.hearingStore.dispatch(new fromHearingStore.LoadHearingValues());
     }
     // Set the navigation url based on the hearing amendments enabled Launch Darkly setting


### PR DESCRIPTION
### Jira link

See [EXUI-3244](https://tools.hmcts.net/jira/browse/EXUI-3244)

### Change description

Dont reset hearing store when cr84 is enabled

### Testing done

Tested locally and with line removed hearings tab no longer hides when hearing clicked
