### PR TITLE
cot-1022 re-naming of button

### DIFF
--- a/src/hearings/components/radio-list-builder/radio-list-builder.component.html
+++ b/src/hearings/components/radio-list-builder/radio-list-builder.component.html
@@ -44,7 +44,7 @@
     </fieldset>
     <div class="govuk-!-padding-top-3">
       <button type="button" class="govuk-button govuk-button--secondary" data-module="govuk-button" (click)="addToList()">
-        Include panel member
+        Include panel role
       </button>
     </div>
   </form>


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/COT-1022

### Change description

It was noted during QA, that the button to add a panel role had the same text as that of the add member.  This was deemed confusing and the wording has been updated.

### Testing done

The renaming of the button has been seen to be applied

### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist


- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
