### PR TITLE
cot-1021 remove cr97 from non cr84 flow

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,8 +2,6 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
-enableStrictSsl: false
-
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.7.0.cjs

--- a/api/hearings/services.index.ts
+++ b/api/hearings/services.index.ts
@@ -37,15 +37,9 @@ export async function loadServiceHearingValues(req: EnhancedRequest, res: Respon
       const { status, data }: { status: number, data: ServiceHearingValuesModel } = await sendPost(markupPath, reqBody, req, next);
       let dataByDefault = mapDataByDefault(data);
       const forceNewDefaultScreenFlow = retrieveForceNewDefaultScreenFlow();
-      trackTrace(`services.index - forceNewDefaultScreenFlow: ${forceNewDefaultScreenFlow}`);
-      console.log(`services.index - forceNewDefaultScreenFlow: ${forceNewDefaultScreenFlow}`);
       if (forceNewDefaultScreenFlow) {
-        trackTrace('services.index - In forceDefaultScreenFlow...');
-        console.log('services.index - In forceDefaultScreenFlow...');
         dataByDefault = forceDefaultScreenFlow(data);
       } else {
-        trackTrace('services.index - Not in forceDefaultScreenFlow...');
-        console.log('services.index - Not in forceDefaultScreenFlow...');
         if (!data.screenFlow) {
           dataByDefault = {
             ...data,
@@ -54,9 +48,6 @@ export async function loadServiceHearingValues(req: EnhancedRequest, res: Respon
           };
         }
       }
-      trackTrace('services.index - dataByDefault.screenFlow:' + JSON.stringify(data.screenFlow));
-      console.log('services.index - dataByDefault.screenFlow:' + JSON.stringify(data.screenFlow));
-
       res.status(status).send(dataByDefault);
     }
   } catch (error) {
@@ -68,8 +59,6 @@ export async function loadServiceHearingValues(req: EnhancedRequest, res: Respon
 export function retrieveForceNewDefaultScreenFlow():boolean {
   try {
     const result = showFeature(FEATURE_FORCE_NEW_DEFAULT_SCREEN_FLOW);
-    trackTrace('services.index - retrieveForceNewDefaultScreenFlow' + result);
-    console.log('services.index - retrieveForceNewDefaultScreenFlow' + result);
     return toBoolean(result);
   } catch {
     return false;
@@ -87,14 +76,10 @@ export function toBoolean(value: unknown): boolean {
 }
 
 export function forceDefaultScreenFlow(data: ServiceHearingValuesModel) {
-  trackTrace('services.index - in forceDefaultScreenFlow '+ JSON.stringify(data.screenFlow));
-  console.log('services.index - in forceDefaultScreenFlow '+ JSON.stringify(data.screenFlow));
   if (!data.screenFlow) {
-    trackTrace('services.index - data.screenFlow is undefined, using DEFAULT_SCREEN_FLOW_NEW');
-    console.log('services.index - data.screenFlow is undefined, using DEFAULT_SCREEN_FLOW_NEW');
     return {
       ...data,
-      screenFlow: DEFAULT_SCREEN_FLOW_NEW
+      screenFlow: (data.panelRequiredDefault !== undefined) ? DEFAULT_SCREEN_FLOW_NEW : DEFAULT_SCREEN_FLOW
     };
   }
   const panelSelectorScreen = data.screenFlow.find((screen) => screen.screenName === 'hearing-panel');
@@ -107,8 +92,6 @@ export function forceDefaultScreenFlow(data: ServiceHearingValuesModel) {
 }
 
 export function replaceScreenFlow(screenFlow: ScreenNavigationModel[], followingScreen: string): ScreenNavigationModel[] {
-  trackTrace('services.index - replaceScreenFlow called with followingScreen:');
-  console.log('services.index - replaceScreenFlow called with followingScreen:');
   // Define the sequence to be replaced
   const toReplaceSequence = ['hearing-venue', 'hearing-welsh', 'hearing-judge', 'hearing-panel'];
 
@@ -141,8 +124,6 @@ export function replaceScreenFlow(screenFlow: ScreenNavigationModel[], following
 
   // Insert the new sequence at the same location
   screenFlow.splice(startIndex, 0, ...newSequence);
-  trackTrace('services.index - replaceScreenFlow screen flow replaced with new sequence: ' + JSON.stringify(screenFlow));
-  console.log('services.index - replaceScreenFlow screen flow replaced with new sequence: ' + JSON.stringify(screenFlow));
   return screenFlow;
 }
 

--- a/src/hearings/containers/request-hearing/hearing-view-edit-summary/hearing-view-edit-summary.component.spec.ts
+++ b/src/hearings/containers/request-hearing/hearing-view-edit-summary/hearing-view-edit-summary.component.spec.ts
@@ -14,15 +14,14 @@ import { ScreenNavigationModel } from 'api/hearings/models/screenNavigation.mode
 import * as fromHearingStore from '../../../../hearings/store';
 import {
   HEARING_JUDGE, HEARING_PANEL, HEARING_PANEL_REQUIRED, HEARING_TIMING, HEARING_VENUE,
-  HEARING_WELSH,
-  replaceResultValue
+  HEARING_WELSH
 } from '../../../../../api/hearings/data/defaultScreenFlow.data';
 
 const screenFlow: ScreenNavigationModel[] = [
-  replaceResultValue(HEARING_VENUE, 'hearing-judge', 'hearing-panel-required'),
-  replaceResultValue(HEARING_WELSH, 'hearing-judge', 'hearing-panel-required'),
+  HEARING_VENUE,
+  HEARING_WELSH,
   HEARING_PANEL_REQUIRED,
-  replaceResultValue(HEARING_JUDGE, 'hearing-panel', 'hearing-timing'),
+  HEARING_JUDGE,
   HEARING_PANEL,
   HEARING_TIMING
 ];
@@ -292,9 +291,9 @@ describe('HearingViewEditSummaryComponent', () => {
       fixture.detectChanges();
       expect(component.template[2].screenName).toEqual('hearing-venue');
       expect(component.template[3].screenName).toEqual('hearing-welsh');
-      expect(component.template[4].screenName).toEqual('hearing-panel-required');
+      expect(component.template[4].screenName).toEqual('hearing-judge');
       expect(component.template[5].screenName).toEqual('hearing-panel');
-      expect(component.template[6].screenName).toEqual('hearing-panel-selector');
+      expect(component.template[6].screenName).toEqual('hearing-timing');
       const scrFl = spyOn(component, 'getScreenFlowFromStore').and.returnValue(of(screenFlow));
       component.getScreenFlowFromStore().subscribe((scr) => {
         expect(scr.length).toEqual(6);
@@ -388,8 +387,7 @@ describe('HearingViewEditSummaryComponent', () => {
       fixture.detectChanges();
       expect(component.template[2].screenName).toEqual('hearing-venue');
       expect(component.template[3].screenName).toEqual('hearing-welsh');
-      expect(component.template[4].screenName).toEqual('hearing-panel-required');
-      expect(component.template[5].screenName).toEqual('hearing-judge');
+      expect(component.template[5].screenName).toEqual('hearing-panel');
       expect(component.template[6].screenName).toEqual('hearing-timing');
       const scrFl = spyOn(component, 'getScreenFlowFromStore').and.returnValue(of(screenFlow));
       component.getScreenFlowFromStore().subscribe((scr) => {

--- a/src/hearings/containers/request-hearing/hearing-view-edit-summary/hearing-view-edit-summary.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-view-edit-summary/hearing-view-edit-summary.component.ts
@@ -10,10 +10,9 @@ import { HearingsService } from '../../../services/hearings.service';
 import * as fromHearingStore from '../../../store';
 import { HEARING_VIEW_EDIT_SUMMARY_TEMPLATE } from '../../../templates/hearing-view-edit-summary.template';
 import { RequestHearingPageFlow } from '../request-hearing.page.flow';
-import { Section } from '../../../../hearings/models/section';
-import { ScreenNavigationModel } from '../../../../hearings/models/screenNavigation.model';
-import { HearingResponseError } from '../../../../hearings/models/hearingResponseError.model';
-import { HearingsUtils } from '../../../utils/hearings.utils';
+import { Section } from '../../../models/section';
+import { ScreenNavigationModel } from '../../../models/screenNavigation.model';
+import { HearingResponseError } from '../../../models/hearingResponseError.model';
 
 @Component({
   selector: 'exui-hearing-view-edit-summary',
@@ -89,9 +88,6 @@ export class HearingViewEditSummaryComponent extends RequestHearingPageFlow impl
             return tp.screenName.includes(sr.screenName) || tp.screenName.includes('edit-hearing') || tp.screenName.includes('hearing-listing-info');
           });
         });
-        if (this.screenFlow.some((sr: ScreenNavigationModel) => sr.screenName === 'hearing-panel-required')) {
-          this.template = HearingsUtils.checkTemplateForHearingPanelRequiremnts(this.template, storeData?.hearings?.hearingRequest?.hearingRequestMainModel?.hearingDetails?.isAPanelFlag);
-        }
       }
     });
     return this.template;

--- a/src/hearings/templates/hearing-view-edit-summary.template.ts
+++ b/src/hearings/templates/hearing-view-edit-summary.template.ts
@@ -164,20 +164,6 @@ export const HEARING_VIEW_EDIT_SUMMARY_TEMPLATE: Section[] = [
     isHiddenSource: IsHiddenSource.WELSH_LOCATION
   },
   {
-    sectionHTMLTitle: '<h2 class="govuk-heading-m">Hearing panel required</h2>',
-    screenName: 'hearing-panel-required',
-    answers: [
-      {
-        id: 'needPanel',
-        answerTitle: 'Do you require a panel for this hearing?',
-        answerSource: AnswerSource.NEED_PANEL,
-        changeLink: '/hearings/request/hearing-panel-required#hearingPanelRequired',
-        isAmendedSource: AnswerSource.NEED_PANEL
-      }
-    ],
-    isHiddenSource: IsHiddenSource.HEARING_PANEL_SELECTOR_EXCLUSION
-  },
-  {
     sectionHTMLTitle: '<h2 class="govuk-heading-m">Judge details</h2>',
     screenName: 'hearing-judge',
     answers: [
@@ -251,37 +237,6 @@ export const HEARING_VIEW_EDIT_SUMMARY_TEMPLATE: Section[] = [
       }
     ],
     isHiddenSource: IsHiddenSource.PANEL_DETAILS_EXCLUSION
-  },
-  {
-    sectionHTMLTitle: '<h2 class="govuk-heading-m">Panel details</h2>',
-    screenName: 'hearing-panel-selector',
-    answers: [
-      {
-        id: 'panelInclusion',
-        answerTitle: 'Include specific panel members',
-        answerSource: AnswerSource.PANEL_INCLUSION,
-        changeLink: '/hearings/request/hearing-panel-selector#inputSelectPersonInclude',
-        isHiddenSource: IsHiddenSource.PANEL_INCLUSION,
-        isAmendedSource: AnswerSource.PANEL_INCLUSION
-      },
-      {
-        id: 'panelExclusion',
-        answerTitle: 'Exclude specific panel members',
-        answerSource: AnswerSource.PANEL_EXCLUSION,
-        changeLink: '/hearings/request/hearing-panel-selector#inputSelectPersonExclude',
-        isHiddenSource: IsHiddenSource.PANEL_EXCLUSION,
-        isAmendedSource: AnswerSource.PANEL_EXCLUSION
-      },
-      {
-        id: 'panelRoles',
-        answerTitle: 'Select any other panel roles required',
-        answerSource: AnswerSource.PANEL_ROLES,
-        changeLink: '/hearings/request/hearing-panel-selector#specificPanelSelection',
-        isHiddenSource: IsHiddenSource.PANEL_ROLES,
-        isAmendedSource: AnswerSource.PANEL_ROLES
-      }
-    ],
-    isHiddenSource: IsHiddenSource.HEARING_PANEL_SELECTOR_EXCLUSION
   },
   {
     sectionHTMLTitle: '<h2 class="govuk-heading-m">Length, date and priority level of hearing</h2>',


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/COT-1021

### Change description

CR97 had been developed to work on all services.  There was a missed requirement that stated that the new functionality should only be developed on the new CR84 journey and not on the old hearing joureny used by services yet to onboard to CR84.  This ticket is for the removal of the changes which had been made to the old journey code and to prevent the setting of the new screen flow for the defaults automatically.  These will only be populated once the onboarding services set the panelRequiredDefault.

### Testing done

The create, view and edit journey have been tested for the old journey using an sscs test case and the new journey has been shown to continue to work as expected using an iac test case. 

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
