### PR TITLE
Fix playwright config, screenshot , video and trace on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Key behaviour:
 - Jenkins automatically publishes the HTML artefact for preview/AAT functional and nightly cross-browser jobs.
 - Run info shows project, release, environment, branch and worker count. Override defaults via `PLAYWRIGHT_REPORT_PROJECT`, `PLAYWRIGHT_REPORT_RELEASE`, `TEST_TYPE`, `GIT_BRANCH` or `FUNCTIONAL_TESTS_WORKERS`.
 - Skipped tests are included in totals; the reporter is patched locally so the dashboard reflects them even when retries are enabled.
+- Chromium runs keep the Playwright trace, failure screenshot and video when a test fails; successful runs discard these artefacts to limit noise.
 
 ### Parallelism
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,10 +58,13 @@ module.exports = defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'],
+      use: {
+        ...devices['Desktop Chrome'],
         channel: 'chrome',
         headless: headlessMode,
-        trace: 'on-first-retry'
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure'
       }
     }
   ]


### PR DESCRIPTION
### Jira link

See [EXUI-3640](https://tools.hmcts.net/jira/browse/EXUI-3640)

### Change description

Configure the Playwright Chromium project to retain traces, screenshots, and videos only for failing scenarios, keeping successful runs free of artefact noise.
Document the new failure-artefact behaviour in the Playwright reporting section of the README.

### Testing done

Not run (config-only change; behaviour verified via configuration review)

### Security Vulnerability Assessment ###

CVE Suppression: Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ x] No

### Checklist

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
