### PR TITLE
Moving amend label, to appear next to the subsection header

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.html
+++ b/src/hearings/containers/request-hearing/hearing-timing/hearing-timing.component.html
@@ -12,7 +12,11 @@
         <div class="govuk-form-group" [ngClass]="{'govuk-form-group--error': hearingLengthErrorValue}">
           <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint" id="hearing-length">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-              <h1 class="govuk-fieldset__heading">{{ 'Length of hearing' | rpxTranslate }}</h1>
+              <h1 class="govuk-fieldset__heading">{{ 'Length of hearing' | rpxTranslate }}
+              <exui-amendment-label id="length-of-hearing-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired && durationChanged"
+                                    [displayLabel]="amendmentLabelEnum.AMENDED">
+              </exui-amendment-label>
+              </h1>
             </legend>
             <span class="govuk-error-message" *ngIf="hearingLengthErrorValue">
               <span class="govuk-visually-hidden">{{ 'Error:' | rpxTranslate }}</span> {{hearingLengthErrorValue | rpxTranslate }}
@@ -39,9 +43,6 @@
                     name="durationmins" type="text" inputmode="numeric" value="" formControlName="minutes">
                 </div>
               </div>
-              <exui-amendment-label id="length-of-hearing-label" *ngIf="!hearingWindowChangesConfirmed && hearingWindowChangesRequired && durationChanged"
-                                    [displayLabel]="amendmentLabelEnum.AMENDED">
-              </exui-amendment-label>
             </div>
           </fieldset>
         </div>


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/CME-829

### Change description

On testing the updated acceptance criteria, it was noted that the amend lable for a change in duration was appearing next to the data, whereas the ac stipulated that this should be next to the sub header. This has been actioned. 

### Testing done

Scenarios tested and label appearing in correct position 

### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change - No
