### PR TITLE
cot-1094 fix to split participants details back to two lines

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-attendance/hearing-attendance.component.html
+++ b/src/hearings/containers/request-hearing/hearing-attendance/hearing-attendance.component.html
@@ -79,7 +79,7 @@
                 <span class="govuk-visually-hidden">{{ 'Error:' | rpxTranslate }}</span> {{ 'Select how each party will attend the hearing' | rpxTranslate }}
               </span>
             <div *ngFor="let partyControl of partiesFormArray.controls; let i=index" class="party-row" [formGroupName]="i">
-              <label class="govuk-label govuk-!-font-weight-bold" [for]="'partyChannel'+i">
+              <label class="govuk-label govuk-!-font-weight-bold party-label-block" [for]="'partyChannel'+i">
                   {{ partyControl.value.partyName }}
                 <exui-amendment-label *ngIf="!partyDetailsChangesConfirmed && partyDetailsChangesRequired && (partyNameAmendmentStatusById[partyControl.value.partyID] || 'NONE') !== 'NONE'"
                   [displayLabel]="partyNameAmendmentStatusById[partyControl.value.partyID]">

--- a/src/hearings/containers/request-hearing/hearing-attendance/hearing-attendance.component.scss
+++ b/src/hearings/containers/request-hearing/hearing-attendance/hearing-attendance.component.scss
@@ -6,15 +6,29 @@
 .party-row {
   margin-bottom: 20px;
 
-  // Amendment label styling for party names
-  .govuk-label {
-    display: inline-block;
-    margin-right: 10px;
+  // Override for party-label-block to ensure it's on its own line
+  .party-label-block {
+    display: block !important;
+    margin-bottom: 0.5rem;
+
+    // Amendment label inside the label should be inline with consistent spacing
+    exui-amendment-label {
+      display: inline-block;
+      margin-left: 10px;
+      vertical-align: middle;
+    }
   }
 
-  exui-amendment-label {
+  // Select dropdown should be inline
+  .govuk-select {
     display: inline-block;
-    margin-left: 5px;
+    margin-right: 0;
+  }
+
+  // Amendment label that appears after the select dropdown
+  .govuk-select ~ exui-amendment-label {
+    display: inline-block;
+    margin-left: 10px;
     vertical-align: middle;
   }
 }
@@ -53,4 +67,3 @@ strong {
     margin-left: 10px;
   }
 }
-


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/COT-1094

### Change description

a previous change to hearing-attendance.component.scss had knocked out the formatting of the participant lines produced, moving the attendance method onto the same line as the name.  This is to ensure that the name and attendance method are produced on two different lines again. 

### Testing done

A number of labelling scenarios have been run through to ensure that they run as expected. 

### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change - no
