### PR TITLE
Push the expect timeout up to 45 seconds, tests are failing with the …

### DIFF
--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -25,7 +25,7 @@ module.exports = defineConfig({
   testMatch: ['**/test/**/*.spec.ts'],
   retries: process.env.CI ? 1 : 0,
   timeout: 120_000,
-  expect: { timeout: 15_000 },
+  expect: { timeout: 45_000 },
   workers: workerCount,
     reporter: [
     [process.env.CI ? 'dot' : 'list'],


### PR DESCRIPTION
### Change description

Push the expect timeout up to 45 seconds, the nightly tests are failing with it set to 15 and this will likely impact PR builds as well.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
