### PR TITLE
missing amended label for participant deletion

### DIFF
--- a/src/hearings/containers/request-hearing/hearing-edit-summary/participant-attendance-section/participant-attendance-section.component.spec.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/participant-attendance-section/participant-attendance-section.component.spec.ts
@@ -308,6 +308,100 @@ describe('ParticipantAttendanceSectionComponent', () => {
       component.ngOnInit();
       expect(component.pageTitleDisplayLabel).toEqual(AmendmentLabelStatus.AMENDED);
     });
+
+    it('should set pageTitleDisplayLabel to amended if number of attendees manually amended by user', () => {
+      hearingsService.propertiesUpdatedOnPageVisit = {
+        hearingId: 'h000001',
+        caseFlags: initialState.hearings.hearingValues.serviceHearingValuesModel.caseFlags,
+        parties: initialState.hearings.hearingValues.serviceHearingValuesModel.parties,
+        hearingWindow: initialState.hearings.hearingValues.serviceHearingValuesModel.hearingWindow,
+        afterPageVisit: {
+          reasonableAdjustmentChangesRequired: false,
+          nonReasonableAdjustmentChangesRequired: false,
+          participantAttendanceChangesRequired: false,
+          hearingWindowChangesRequired: false,
+          hearingFacilitiesChangesRequired: false,
+          hearingUnavailabilityDatesChanged: false,
+          additionalInstructionsChangesRequired: false
+        }
+      };
+      component.hearingRequestMainModel = {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+        partyDetails: [
+          ...initialState.hearings.hearingRequest.hearingRequestMainModel.partyDetails,
+          {
+            partyID: 'P999',
+            partyType: 'IND' as any,
+            partyRole: 'appellant',
+            individualDetails: {
+              firstName: 'New',
+              lastName: 'Party',
+              preferredHearingChannel: 'byVideo'
+            }
+          } as any
+        ]
+      };
+      component.ngOnInit();
+      expect(component.pageTitleDisplayLabel).toEqual(AmendmentLabelStatus.AMENDED);
+    });
+
+    it('should set pageTitleDisplayLabel to amended when number of attendees decreased', () => {
+      hearingsService.propertiesUpdatedOnPageVisit = {
+        hearingId: 'h000001',
+        caseFlags: initialState.hearings.hearingValues.serviceHearingValuesModel.caseFlags,
+        parties: initialState.hearings.hearingValues.serviceHearingValuesModel.parties,
+        hearingWindow: initialState.hearings.hearingValues.serviceHearingValuesModel.hearingWindow,
+        afterPageVisit: {
+          reasonableAdjustmentChangesRequired: false,
+          nonReasonableAdjustmentChangesRequired: false,
+          participantAttendanceChangesRequired: false,
+          hearingWindowChangesRequired: false,
+          hearingFacilitiesChangesRequired: false,
+          hearingUnavailabilityDatesChanged: false,
+          additionalInstructionsChangesRequired: false
+        }
+      };
+      component.hearingRequestMainModel = {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+        partyDetails: []
+      };
+      component.hearingRequestToCompareMainModel = {
+        ...initialState.hearings.hearingRequestToCompare.hearingRequestMainModel,
+        partyDetails: []
+      };
+      component.ngOnInit();
+      expect(component.pageTitleDisplayLabel).toEqual(AmendmentLabelStatus.AMENDED);
+    });
+
+    it('should set pageTitleDisplayLabel to none when number of attendees unchanged and no other changes', () => {
+      hearingsService.propertiesUpdatedOnPageVisit = {
+        hearingId: 'h000001',
+        caseFlags: initialState.hearings.hearingValues.serviceHearingValuesModel.caseFlags,
+        parties: initialState.hearings.hearingValues.serviceHearingValuesModel.parties,
+        hearingWindow: initialState.hearings.hearingValues.serviceHearingValuesModel.hearingWindow,
+        afterPageVisit: {
+          reasonableAdjustmentChangesRequired: false,
+          nonReasonableAdjustmentChangesRequired: false,
+          participantAttendanceChangesRequired: true,
+          participantAttendanceChangesConfirmed: true,
+          hearingWindowChangesRequired: false,
+          hearingFacilitiesChangesRequired: false,
+          hearingUnavailabilityDatesChanged: false,
+          additionalInstructionsChangesRequired: false
+        }
+      };
+      component.hearingRequestMainModel = {
+        ...initialState.hearings.hearingRequest.hearingRequestMainModel,
+        hearingDetails: {
+          ...initialState.hearings.hearingRequest.hearingRequestMainModel.hearingDetails,
+          hearingChannels: initialState.hearings.hearingRequestToCompare.hearingRequestMainModel.hearingDetails.hearingChannels,
+          numberOfPhysicalAttendees: initialState.hearings.hearingRequestToCompare.hearingRequestMainModel.hearingDetails.numberOfPhysicalAttendees
+        },
+        partyDetails: initialState.hearings.hearingRequestToCompare.hearingRequestMainModel.partyDetails
+      };
+      component.ngOnInit();
+      expect(component.pageTitleDisplayLabel).toEqual(AmendmentLabelStatus.NONE);
+    });
   });
   describe('ParticipantAttendanceSectionComponent - getPartyChannelChanged', () => {
     let testComponent: ParticipantAttendanceSectionComponent;

--- a/src/hearings/containers/request-hearing/hearing-edit-summary/participant-attendance-section/participant-attendance-section.component.ts
+++ b/src/hearings/containers/request-hearing/hearing-edit-summary/participant-attendance-section/participant-attendance-section.component.ts
@@ -33,10 +33,6 @@ export class ParticipantAttendanceSectionComponent implements OnInit {
   public partyDetailsChangesRequired: boolean;
   public partyDetailsChangesConfirmed: boolean;
   public isPaperHearingChanged: boolean;
-  public numberOfPhysicalAttendeesChanged: boolean;
-  public methodOfAttendanceChanged: boolean;
-  public participantChannelsChanged: boolean;
-  public participantNameChanged: boolean;
   public amendmentLabelEnum = AmendmentLabelStatus;
 
   constructor(private readonly hearingsService: HearingsService) {}
@@ -178,25 +174,31 @@ export class ParticipantAttendanceSectionComponent implements OnInit {
       || !!this.hearingRequestMainModel.hearingDetails.isPaperHearing)
     );
 
-    this.numberOfPhysicalAttendeesChanged = !_.isEqual(
+    const numberOfPhysicalAttendeesChanged = !_.isEqual(
       this.hearingRequestToCompareMainModel.hearingDetails?.numberOfPhysicalAttendees || 0,
       this.hearingRequestMainModel.hearingDetails?.numberOfPhysicalAttendees || 0
     );
 
-    this.methodOfAttendanceChanged = !_.isEqual(
+    const numberOfAttendeesChanged = !_.isEqual(
+      this.hearingRequestToCompareMainModel?.partyDetails.length || 0,
+      this.hearingRequestMainModel?.partyDetails.length || 0,
+    );
+
+    const methodOfAttendanceChanged = !_.isEqual(
       this.hearingRequestToCompareMainModel.hearingDetails?.hearingChannels,
       this.hearingRequestMainModel.hearingDetails?.hearingChannels || []
     );
 
-    this.participantChannelsChanged = this.participantAttendanceModes.some((mode) => mode.partyChannelChanged === true);
+    const participantChannelsChanged = this.participantAttendanceModes.some((mode) => mode.partyChannelChanged === true);
 
-    this.participantNameChanged = this.participantAttendanceModes.some((mode) => mode.partyNameChanged === true);
+    const participantNameChanged = this.participantAttendanceModes.some((mode) => mode.partyNameChanged === true);
 
     const changesMadeToParticipantAttendance = this.isPaperHearingChanged ||
-      this.numberOfPhysicalAttendeesChanged ||
-      this.methodOfAttendanceChanged ||
-      this.participantChannelsChanged ||
-      this.participantNameChanged;
+      numberOfPhysicalAttendeesChanged ||
+      numberOfAttendeesChanged ||
+      methodOfAttendanceChanged ||
+      participantChannelsChanged ||
+      participantNameChanged;
 
     if (this.partyDetailsChangesRequired) {
       if (!this.partyDetailsChangesConfirmed) {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/COT-1091

### Change description

For the scenario when a participant has been deleted and no further changes made.  The section sub header should have had an amended label displayed.  I have introduced a check to verify that the number of participants before and after are the same or not. If this differs, this will trigger the required labelling. 

### Testing done

The scenario of a deleted participant has been tested and all unit tests have been run.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - no break
