### PR TITLE
CVE-2022-25896: CVE-2022-25896 remediation plan for rpx-xui-webapp

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,7 +310,8 @@
     "semver": "^7.6.3",
     "superagent": "^10.2.2",
     "cookie": "^0.7.2",
-    "min-document": "^2.19.1"
+    "min-document": "^2.19.1",
+    "passport": "0.7.0"
   },
   "packageManager": "yarn@4.7.0"
 }


### PR DESCRIPTION
Summary:
Pinned passport to 0.7.0 via root resolutions to ensure the patched version is enforced for CVE-2022-25896.

Plan ID: 29712276-ee51-4cdf-8f6e-713cd0cefd47