### PR TITLE
EXUI-4323 - no userID passed in cookies 3

### DIFF
--- a/charts/xui-webapp/values.aat.template.yaml
+++ b/charts/xui-webapp/values.aat.template.yaml
@@ -8,6 +8,10 @@ nodejs:
   environment:
     NODE_TLS_REJECT_UNAUTHORIZED: 1
     FEATURE_JRD_E_LINKS_V2_ENABLED: true
+    SERVICES_IDAM_SERVICE_OVERRIDE: false
+    SERVICES_IDAM_ISS_URL: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/realms/root/realms/hmcts
+    FEATURE_OIDC_ENABLED: true
+    FEATURE_QUERY_IDAM_SERVICE_OVERRIDE: false
     HEALTH_CCD_COMPONENT_API: https://gateway-ccd.{{ .Values.global.environment }}.platform.hmcts.net
     HEALTH_CCD_DATA_API: http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     HEALTH_DOCUMENTS_API: http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/health

--- a/playwright_tests_new/integration/test/manageTasks/caseTaskList/caseTaskList.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/caseTaskList/caseTaskList.positive.spec.ts
@@ -40,8 +40,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe(`User ${userIdentifier} can see assigned tasks on a case`, () => {
-  // Skipping until Master build staging issue is resolved - EXUI-4323
-  test.skip(`Low priority tasks assigned to logged in user show elements and markdown as expected`, async ({
+  test(`Low priority tasks assigned to logged in user show elements and markdown as expected`, async ({
     caseDetailsPage,
     page,
   }) => {
@@ -106,8 +105,7 @@ test.describe(`User ${userIdentifier} can see assigned tasks on a case`, () => {
         .toContain('Next steps Please review the evidence before proceeding.');
     });
   });
-  // Skipping until Master build staging issue is resolved - EXUI-4323
-  test.skip(`Priority labels render as in order for each task depending on major priority rate and date`, async ({
+  test(`Priority labels render as in order for each task depending on major priority rate and date`, async ({
     caseDetailsPage,
     page,
   }) => {

--- a/playwright_tests_new/integration/test/manageTasks/myTasks/taskCompletion.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/myTasks/taskCompletion.positive.spec.ts
@@ -12,8 +12,7 @@ test.beforeEach(async ({ page }) => {
   taskListMockResponse = buildTaskListMock(160, userId, myActionsList);
 });
 
-// Skipping until Master build staging issue is resolved - EXUI-4323
-test.describe.skip(`Task Completion as ${userIdentifier}`, { tag: ['@integration', '@integration-manage-tasks'] }, () => {
+test.describe(`Task Completion as ${userIdentifier}`, { tag: ['@integration', '@integration-manage-tasks'] }, () => {
   test(`User can mark one of their assigned tasks as done`, async ({ taskListPage, page }) => {
     const firstTask = taskListMockResponse.tasks[0];
 

--- a/playwright_tests_new/integration/utils/extractUserIdFromCookies.ts
+++ b/playwright_tests_new/integration/utils/extractUserIdFromCookies.ts
@@ -1,10 +1,23 @@
+import { logger } from '../../E2E/utils/logger.utils';
+
 /**
  * Extracts the __userid__ value from a cookies array.
  * @param {Array} cookies - Array of cookie objects (from session).
  * @returns {string|null} The __userid__ value, or null if not found.
  */
 export function extractUserIdFromCookies(cookies: any[]): string | null {
-  if (!Array.isArray(cookies)) return null;
+  if (!Array.isArray(cookies)) {
+    logger.info('extractUserIdFromCookies received a non-array cookies value', { hasUserId: false });
+    return null;
+  }
   const userIdCookie = cookies.find((c) => c.name === '__userid__');
-  return userIdCookie ? userIdCookie.value : null;
+  const userId = userIdCookie ? userIdCookie.value : null;
+
+  logger.info('extractUserIdFromCookies evaluated session cookies', {
+    hasUserId: Boolean(userId),
+    userIdLength: userId?.length ?? 0,
+    cookieCount: cookies.length,
+  });
+
+  return userId;
 }


### PR DESCRIPTION
Follow up to this [reverted pr](https://github.com/hmcts/rpx-xui-webapp/pull/5073) which had a green build after merging to master but was reverted so we could unskip tests which would expose logs needed for QA'ing:

### Jira link

See [EXUI-4323](https://tools.hmcts.net/jira/browse/EXUI-4323)

### Change description

Updated the auth-related config in `charts/xui-webapp/values.aat.template.yaml` so the master build staging env uses the same OIDC setup expected by [current prod config from flux](https://github.com/hmcts/cnp-flux-config/blob/master/apps/xui/xui-webapp/prod.yaml).

This [staging env relies on the values.aat.teplate.yaml](https://build.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Frpx-xui-webapp/detail/master/1613/pipeline/438/#step-525-log-1) which inherits and overwrites the value.yaml defaults, whereas the deployed prod webapp receives auth overrides from flux config. As a result, master staging was still picking up an incomplete auth configuration even after enabling OIDC in pr: https://github.com/hmcts/rpx-xui-webapp/pull/5024.

### Testing done

To be done on master staging env

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No