### PR TITLE
Improve Playwright integration tests manage-tasks coverage - EXUI-4511

### DIFF
--- a/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskEventCompletion.negative.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskEventCompletion.negative.spec.ts
@@ -20,6 +20,7 @@ const eventTriggerResponse = buildCaseEventTriggerMock({
   eventName,
   description: 'Complete the selected case task event',
 });
+const tasksTabPath = `/cases/case-details/IA/Asylum/${caseId}/tasks`;
 
 test.describe(`Task event completion as ${userIdentifier}`, { tag: ['@integration', '@integration-manage-tasks'] }, () => {
   test('shows the no task available validation when the selected event has no completable tasks', async ({
@@ -58,12 +59,14 @@ test.describe(`Task event completion as ${userIdentifier}`, { tag: ['@integratio
     });
 
     await test.step('Verify the no task available validation content', async () => {
+      await expect(page).toHaveURL(/\/no-tasks-available$/);
       await expect(caseDetailsPage.generalProblemHeading).toHaveText(/There is a problem/i);
-      await expect(page.locator('.govuk-error-summary')).toContainText('No task available');
-      await expect(page.locator('.govuk-form-group--error')).toContainText(
-        'You should have an assigned task for this event, but something has gone wrong'
-      );
-      await expect(page.getByRole('link', { name: 'Return to tasks tab' })).toBeVisible();
+      await expect(page.locator('.govuk-error-summary__body')).toContainText('No task available');
+      await expect(page.getByRole('heading', { name: 'No task available' })).toBeVisible();
+      await expect(page.getByText('You should have an assigned task for this event, but something has gone wrong')).toBeVisible();
+      const returnToTasksLink = page.getByRole('link', { name: 'Return to tasks tab' });
+      await expect(returnToTasksLink).toBeVisible();
+      await expect(returnToTasksLink).toHaveAttribute('href', tasksTabPath);
     });
   });
 
@@ -112,9 +115,14 @@ test.describe(`Task event completion as ${userIdentifier}`, { tag: ['@integratio
     await test.step('Verify the task assignment required validation content', async () => {
       await expect(page).toHaveURL(/\/task-unassigned$/);
       await expect(caseDetailsPage.generalProblemHeading).toHaveText(/There is a problem/i);
-      await expect(page.locator('.govuk-error-summary')).toContainText('Task assignment required');
-      await expect(page.locator('.govuk-form-group--error')).toContainText('You must assign one');
-      await expect(page.getByRole('link', { name: 'Return to tasks tab' })).toBeVisible();
+      await expect(page.locator('.govuk-error-summary__body')).toContainText('Task assignment required');
+      await expect(page.getByRole('heading', { name: 'Task assignment required' })).toBeVisible();
+      await expect(
+        page.getByText('You must assign one of the available tasks from the task tab to continue with your work.')
+      ).toBeVisible();
+      const returnToTasksLink = page.getByRole('link', { name: 'Return to tasks tab to assign a task' });
+      await expect(returnToTasksLink).toBeVisible();
+      await expect(returnToTasksLink).toHaveAttribute('href', tasksTabPath);
     });
   });
 });

--- a/test_codecept/codeceptCommon/codecept.conf.ts
+++ b/test_codecept/codeceptCommon/codecept.conf.ts
@@ -151,7 +151,6 @@ const CODECEPT_OUT = path.resolve(
 
 const CUKE_OUT = path.resolve(__dirname, '../../functional-output/tests/codecept-' + testType);
 fs.mkdirSync(CUKE_OUT, { recursive: true });
-clearLegacyCucumberArtifacts(CUKE_OUT);
 const CUCUMBER_REPORT_FILE = path.join(CUKE_OUT, 'cucumber_report.html');
 
 const debugMode = process.env.DEBUG?.includes('true') ?? false;
@@ -195,6 +194,12 @@ const hasNoSelectableNgIntegrationScenarios =
 console.log(grepTags);
 if (testType === 'ngIntegration') {
   console.log(`Selected ngIntegration scenarios for @${tags}: ${selectedNgIntegrationScenarioCount}`);
+}
+
+function prepareNgIntegrationLegacyArtifacts() {
+  if (testType === 'ngIntegration') {
+    clearLegacyCucumberArtifacts(CUKE_OUT);
+  }
 }
 
 exports.config = {
@@ -268,12 +273,16 @@ exports.config = {
       users: [],
       reuseCounter: 0,
     });
+    if (!parallel) {
+      prepareNgIntegrationLegacyArtifacts();
+    }
     if (!parallel && testType !== 'smoke') {
       // smoke tests are run in serial even with PARALLEL=true
       await setup();
     }
   },
   bootstrapAll: async () => {
+    prepareNgIntegrationLegacyArtifacts();
     globalThis.scenarioData = {};
     await import(path.resolve(__dirname, './hooks.js')); // 🟢 Will now run your hook IIFE immediately
 

--- a/test_codecept/codeceptCommon/codecept.conf.ts
+++ b/test_codecept/codeceptCommon/codecept.conf.ts
@@ -53,6 +53,88 @@ function findStepFiles(basePath) {
   return results;
 }
 
+function findFeatureFiles(basePath) {
+  const results = [];
+
+  function walk(dir) {
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+      const fullPath = path.join(dir, file);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else if (file.endsWith('.feature')) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(basePath);
+  return results;
+}
+
+function clearLegacyCucumberArtifacts(outputDir: string) {
+  if (!fs.existsSync(outputDir)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(outputDir)) {
+    if (entry === 'cucumber_report.html' || (entry.startsWith('cucumber_output_') && entry.endsWith('.json'))) {
+      fs.rmSync(path.join(outputDir, entry), { force: true });
+    }
+  }
+}
+
+function countSelectableScenarios(featureBasePath: string, requiredTag: string) {
+  const requiredTagToken = `@${requiredTag}`;
+  return findFeatureFiles(featureBasePath).reduce((total, featurePath) => {
+    return total + countSelectableScenariosInFeature(featurePath, requiredTagToken);
+  }, 0);
+}
+
+function countSelectableScenariosInFeature(featurePath: string, requiredTagToken: string) {
+  const lines = fs.readFileSync(featurePath, 'utf8').split(/\r?\n/);
+  let featureTags: string[] = [];
+  let pendingTags: string[] = [];
+  let selectableScenarioCount = 0;
+
+  for (const rawLine of lines) {
+    const trimmedLine = rawLine.trim();
+    if (!trimmedLine || trimmedLine.startsWith('#')) {
+      continue;
+    }
+
+    if (trimmedLine.startsWith('@')) {
+      pendingTags = [...pendingTags, ...trimmedLine.split(/\s+/).filter((tag) => tag.startsWith('@'))];
+      continue;
+    }
+
+    if (trimmedLine.startsWith('Feature:')) {
+      featureTags = [...pendingTags];
+      pendingTags = [];
+      continue;
+    }
+
+    if (trimmedLine.startsWith('Scenario:') || trimmedLine.startsWith('Scenario Outline:')) {
+      const combinedTags = new Set([...featureTags, ...pendingTags]);
+      pendingTags = [];
+      if (combinedTags.has(requiredTagToken) && !combinedTags.has('@ignore')) {
+        selectableScenarioCount++;
+      }
+      continue;
+    }
+
+    if (trimmedLine.startsWith('Rule:') || trimmedLine.startsWith('Background:') || trimmedLine.startsWith('Examples:')) {
+      pendingTags = [];
+      continue;
+    }
+
+    pendingTags = [];
+  }
+
+  return selectableScenarioCount;
+}
+
 const e2eStepFiles = findStepFiles(path.resolve(__dirname, '../e2e/features/step_definitions'));
 const ngIntegrationStepFiles = findStepFiles(path.resolve(__dirname, '../ngIntegration/tests/stepDefinitions'));
 
@@ -69,6 +151,8 @@ const CODECEPT_OUT = path.resolve(
 
 const CUKE_OUT = path.resolve(__dirname, '../../functional-output/tests/codecept-' + testType);
 fs.mkdirSync(CUKE_OUT, { recursive: true });
+clearLegacyCucumberArtifacts(CUKE_OUT);
+const CUCUMBER_REPORT_FILE = path.join(CUKE_OUT, 'cucumber_report.html');
 
 const debugMode = process.env.DEBUG?.includes('true') ?? false;
 
@@ -102,7 +186,16 @@ if (pipelineBranch === 'master' && testType === 'ngIntegration') {
 
 const tags = process.env.DEBUG ? 'functional_debug' : bddTags;
 const grepTags = `(?=.*@${testType === 'smoke' ? 'smoke' : tags})^(?!.*@ignore)`;
+const selectedNgIntegrationScenarioCount =
+  testType === 'ngIntegration'
+    ? countSelectableScenarios(path.resolve(__dirname, '../ngIntegration/tests/features'), tags)
+    : undefined;
+const hasNoSelectableNgIntegrationScenarios =
+  testType === 'ngIntegration' && selectedNgIntegrationScenarioCount !== undefined && selectedNgIntegrationScenarioCount === 0;
 console.log(grepTags);
+if (testType === 'ngIntegration') {
+  console.log(`Selected ngIntegration scenarios for @${tags}: ${selectedNgIntegrationScenarioCount}`);
+}
 
 exports.config = {
   require: [path.resolve(__dirname, 'steps_file.js')],
@@ -216,6 +309,10 @@ function exitWithStatus() {
       .map((f) => path.join(CUKE_OUT, f));
 
     if (cucumberReports.length === 0) {
+      if (hasNoSelectableNgIntegrationScenarios) {
+        console.warn('No selectable ngIntegration scenarios remain after retirement markers - passing legacy suite');
+        process.exit(0);
+      }
       console.warn('No cucumber JSON files found - failing the run');
       process.exit(1);
     }
@@ -252,7 +349,11 @@ function exitWithStatus() {
       }
     }
 
-    const status = nonEmpty === 0 ? 'FAIL' : failedScenarios > 0 ? 'FAIL' : 'PASS';
+    if (nonEmpty === 0 && hasNoSelectableNgIntegrationScenarios) {
+      console.warn('No selectable ngIntegration scenarios produced cucumber data - passing retired legacy suite');
+    }
+    const status =
+      nonEmpty === 0 ? (hasNoSelectableNgIntegrationScenarios ? 'PASS' : 'FAIL') : failedScenarios > 0 ? 'FAIL' : 'PASS';
     console.log(
       `Non-empty reports: ${nonEmpty}, Failed scenarios: ${failedScenarios}, Failed steps: ${failedSteps}, Status: ${status}`
     );
@@ -318,6 +419,10 @@ async function generateCucumberReport() {
     });
 
   if (jsonFiles.length === 0) {
+    if (hasNoSelectableNgIntegrationScenarios) {
+      writeRetiredLegacySuiteReport();
+      return;
+    }
     console.warn('⚠️  No cucumber JSONs with features – skipping HTML report');
     return; // nothing to show, so don’t throw
   }
@@ -335,13 +440,11 @@ async function generateCucumberReport() {
     }
   }
 
-  const reportFile = path.join(CUKE_OUT, 'cucumber_report.html');
-
   await new Promise((r) => setTimeout(r, 2000)); // let reporters flush
   report.generate({
     theme: 'bootstrap',
     jsonDir: CUKE_OUT, // folder that holds all accepted files
-    output: reportFile,
+    output: CUCUMBER_REPORT_FILE,
     reportSuiteAsScenarios: true,
     launchReport: false,
     ignoreBadJsonFile: true,
@@ -352,6 +455,25 @@ async function generateCucumberReport() {
     },
   });
   console.log('completed cucumber report');
+}
+
+function writeRetiredLegacySuiteReport() {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Legacy Codecept Integration Test Retired</title>
+  </head>
+  <body>
+    <h1>Legacy Codecept Integration Test Retired</h1>
+    <p>No selectable ngIntegration scenarios remain after retirement markers for this run.</p>
+    <p>This placeholder report is generated so Jenkins can publish the retired legacy stage without failing.</p>
+    <p>Generated at ${new Date().toISOString()}.</p>
+  </body>
+</html>`;
+
+  fs.writeFileSync(CUCUMBER_REPORT_FILE, html, 'utf8');
+  console.log('Generated retired legacy suite placeholder report');
 }
 
 function resolvePipelineBranch(isExternal: boolean, testUrl: string) {

--- a/test_codecept/ngIntegration/tests/features/workallocation2/taskEventCompletion/taskEventCompletion.feature
+++ b/test_codecept/ngIntegration/tests/features/workallocation2/taskEventCompletion/taskEventCompletion.feature
@@ -66,6 +66,8 @@ Feature: WA Release 2: Case events and Task completion and states when task_requ
             | caseworker-ia,caseworker-ia-caseofficer,caseworker-ia-admofficer,task-supervisor |
 
 
+    @ignore
+    # Legacy Codecept scenario retained for reference only. Active coverage lives in playwright_tests_new/integration/test/manageTasks/caseTaskList/taskEventCompletion.negative.spec.ts.
     Scenario Outline: Task not assigned
 
         Given I set MOCK with user "IAC_CaseOfficer_R2" and roles "<roles>,task-supervisor,case-allocator" with reference "userDetails"

--- a/test_codecept/ngIntegration/tests/features/workallocation2/taskEventCompletion/taskEventCompletion.feature
+++ b/test_codecept/ngIntegration/tests/features/workallocation2/taskEventCompletion/taskEventCompletion.feature
@@ -1,5 +1,4 @@
 
-@functional_enabled
 Feature: WA Release 2: Case events and Task completion and states when task_required is true
 
     Background: Setup


### PR DESCRIPTION
### Jira link

See [EXUI-4511](https://tools.hmcts.net/jira/browse/EXUI-4511)

### Change description

- strengthen `taskEventCompletion.negative.spec.ts` so the Playwright replacement asserts the current validation contract for both negative task-event-completion paths
- retire the legacy `Task not assigned` scenario and remove the remaining feature-level `@functional_enabled` marker from `taskEventCompletion.feature`
- make the legacy `ngIntegration` runner safe once no selectable Codecept scenarios remain by clearing stale cucumber artifacts, counting selectable scenarios at scenario level, and generating a placeholder `cucumber_report.html` for Jenkins

### Dependency PRs

- N/A

### Testing done

Automated:
- `PATH="$PWD/node_modules/.bin:$PATH" yarn lint` (passes with 0 errors; repo has an existing 479-warning baseline)
- `npx playwright test --config=playwright.integration.config.ts playwright_tests_new/integration/test/manageTasks/caseTaskList/taskEventCompletion.negative.spec.ts` (`2 passed`)
- `mkdir -p functional-output/tests/codecept-ngIntegration && printf '[{"elements":[{"steps":[{"result":{"status":"failed"}}]}]}]' > functional-output/tests/codecept-ngIntegration/cucumber_output_stale.json && EXTERNAL_SERVERS=true NODE_CONFIG_ENV=mock TEST_TYPE=ngIntegration PARALLEL=true npx codeceptjs run-workers --suites 8 --config ./test_codecept/codeceptCommon/codecept.conf.ts --features` (`0 passed`, legacy suite exits `PASS`, placeholder report generated)

Manual:
- N/A

Evidence:
- HTML: `functional-output/tests/codecept-ngIntegration/cucumber_report.html`
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
