### PR TITLE
test: add EXUI-4512B manage-links and roles coverage

### DIFF
--- a/playwright_tests_new/E2E/page-objects/pages/exui/rolesAccess.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/rolesAccess.po.ts
@@ -4,7 +4,13 @@ import { Base } from '../../base';
 export class RolesAccessPage extends Base {
   readonly heading = this.page.getByRole('heading', { name: 'Roles and access' });
   readonly tabPanel = this.page.getByRole('tabpanel', { name: 'Roles and access' });
+  readonly mainContent = this.page.locator('main');
   readonly personSearchInput = this.page.locator('#inputSelectPerson');
+  readonly continueButton = this.page.getByRole('button', { name: 'Continue' });
+  readonly confirmAllocationButton = this.page.getByRole('button', { name: 'Confirm allocation' });
+  readonly removeAllocationButton = this.page.getByRole('button', { name: 'Remove allocation' });
+  readonly confirmExclusionButton = this.page.getByRole('button', { name: 'Confirm exclusion' });
+  readonly indefiniteDurationRadio = this.page.getByLabel('Indefinite');
   readonly autocompleteOverlay = this.page.locator('.cdk-overlay-pane').filter({
     has: this.page.locator('[role="option"]'),
   });
@@ -21,6 +27,30 @@ export class RolesAccessPage extends Base {
     return this.tabPanel.getByRole('link', { name, exact: true });
   }
 
+  public getAllocateJudicialRoleLink() {
+    return this.getLink('Allocate a judicial role');
+  }
+
+  public getAllocateLegalOpsRoleLink() {
+    return this.getLink('Allocate a legal ops role');
+  }
+
+  public getManageLinks() {
+    return this.getLink('Manage');
+  }
+
+  public getDeleteLinks() {
+    return this.getLink('Delete');
+  }
+
+  public getReallocateLinks() {
+    return this.getLink('Reallocate');
+  }
+
+  public getRemoveAllocationLinks() {
+    return this.getLink('Remove Allocation');
+  }
+
   public getExclusionsAddLink() {
     return this.page.getByRole('heading', { name: 'Exclusions' }).locator('xpath=following::a[normalize-space()="Add"][1]');
   }
@@ -29,6 +59,58 @@ export class RolesAccessPage extends Base {
     return this.page.locator(
       `xpath=//div[contains(@class,"govuk-summary-list__row")][.//*[contains(@class,"govuk-summary-list__key") and normalize-space(.)="${label}"]]`
     );
+  }
+
+  public getSummaryChangeButton(label: string) {
+    return this.getSummaryRow(label).getByRole('button', { name: /change/i });
+  }
+
+  public getRadio(name: string) {
+    return this.page.getByRole('radio', { name });
+  }
+
+  public async continue(): Promise<void> {
+    await this.continueButton.click();
+  }
+
+  public async confirmAllocation(): Promise<void> {
+    await this.confirmAllocationButton.click();
+  }
+
+  public async confirmExclusion(): Promise<void> {
+    await this.confirmExclusionButton.click();
+  }
+
+  public async removeAllocation(): Promise<void> {
+    await this.removeAllocationButton.click();
+  }
+
+  public async selectIndefiniteDuration(): Promise<void> {
+    await this.indefiniteDurationRadio.check({ force: true });
+  }
+
+  public async openFirstManageLink(): Promise<void> {
+    await this.getManageLinks().first().click();
+  }
+
+  public async openFirstReallocateLink(): Promise<void> {
+    await this.getReallocateLinks().first().click();
+  }
+
+  public async openFirstRemoveAllocationLink(): Promise<void> {
+    await this.getRemoveAllocationLinks().first().click();
+  }
+
+  public async chooseExclusionForAnotherPerson(): Promise<void> {
+    await this.getRadio('Exclude another person').check({ force: true });
+  }
+
+  public async chooseJudicialPersonRole(): Promise<void> {
+    await this.getRadio('Judicial').check({ force: true });
+  }
+
+  public async fillExclusionDescription(description: string): Promise<void> {
+    await this.page.locator('#exclusion-description').fill(description);
   }
 
   public async searchAndSelectPerson(searchTerm: string, optionName: string): Promise<void> {

--- a/playwright_tests_new/E2E/page-objects/pages/exui/rolesAccess.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/rolesAccess.po.ts
@@ -1,0 +1,43 @@
+import { expect } from '@playwright/test';
+import { Base } from '../../base';
+
+export class RolesAccessPage extends Base {
+  readonly heading = this.page.getByRole('heading', { name: 'Roles and access' });
+  readonly tabPanel = this.page.getByRole('tabpanel', { name: 'Roles and access' });
+  readonly personSearchInput = this.page.locator('#inputSelectPerson');
+  readonly autocompleteOverlay = this.page.locator('.cdk-overlay-pane').filter({
+    has: this.page.locator('[role="option"]'),
+  });
+
+  public async open(caseId: string): Promise<void> {
+    await this.page.goto(`/cases/case-details/IA/Asylum/${caseId}/roles-and-access`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await this.page.waitForURL(new RegExp(`/cases/case-details/IA/Asylum/${caseId}/roles-and-access(?:\\?.*)?$`));
+    await expect(this.heading).toBeVisible();
+  }
+
+  public getLink(name: string) {
+    return this.tabPanel.getByRole('link', { name, exact: true });
+  }
+
+  public getExclusionsAddLink() {
+    return this.page.getByRole('heading', { name: 'Exclusions' }).locator('xpath=following::a[normalize-space()="Add"][1]');
+  }
+
+  public getSummaryRow(label: string) {
+    return this.page.locator(
+      `xpath=//div[contains(@class,"govuk-summary-list__row")][.//*[contains(@class,"govuk-summary-list__key") and normalize-space(.)="${label}"]]`
+    );
+  }
+
+  public async searchAndSelectPerson(searchTerm: string, optionName: string): Promise<void> {
+    const matchingOption = this.autocompleteOverlay.last().getByRole('option', { name: new RegExp(optionName, 'i') });
+
+    await this.personSearchInput.fill('');
+    await this.personSearchInput.fill(searchTerm);
+    await this.autocompleteOverlay.last().waitFor({ state: 'visible' });
+    await matchingOption.click();
+    await expect(this.personSearchInput).toHaveValue(new RegExp(optionName, 'i'));
+  }
+}

--- a/playwright_tests_new/E2E/page-objects/pages/exui/taskList.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/taskList.po.ts
@@ -554,9 +554,20 @@ export class TaskListPage extends Base {
     await this.confirmCancelTaskButton.click();
   }
 
-  async selectFirstReassignUserOption() {
-    await this.reassignUserAutocompleteOverlay.waitFor({ state: 'visible' });
-    await this.reassignUserAutocompleteFirstOption.click();
+  async selectFirstReassignUserOption(optionName?: string) {
+    const autocompleteOverlay = this.reassignUserAutocompleteOverlay.filter({
+      has: this.page.locator('[role="option"]'),
+    });
+    const option = optionName
+      ? autocompleteOverlay.last().getByRole('option', { name: new RegExp(optionName, 'i') })
+      : this.reassignUserAutocompleteFirstOption;
+
+    await autocompleteOverlay.last().waitFor({ state: 'visible' });
+    await option.click();
+
+    if (optionName) {
+      await expect(this.reassignUserSearchInput).toHaveValue(new RegExp(optionName, 'i'));
+    }
   }
 
   async waitForManageButton(

--- a/playwright_tests_new/E2E/page-objects/pages/exui/taskList.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/taskList.po.ts
@@ -555,15 +555,18 @@ export class TaskListPage extends Base {
   }
 
   async selectFirstReassignUserOption(optionName?: string) {
-    const autocompleteOverlay = this.reassignUserAutocompleteOverlay.filter({
-      has: this.page.locator('[role="option"]'),
-    });
-    const option = optionName
-      ? autocompleteOverlay.last().getByRole('option', { name: new RegExp(optionName, 'i') })
-      : this.reassignUserAutocompleteFirstOption;
+    const selectableOptions = this.page.getByRole('option').filter({ hasNotText: 'No results found' });
+    const namedOption = optionName ? selectableOptions.filter({ hasText: new RegExp(optionName, 'i') }).first() : null;
+    const option = (namedOption && (await namedOption.count())) > 0 ? namedOption : selectableOptions.first();
 
-    await autocompleteOverlay.last().waitFor({ state: 'visible' });
-    await option.click();
+    try {
+      await expect(option).toBeVisible({ timeout: 2_000 });
+      await option.click();
+    } catch {
+      await this.reassignUserSearchInput.focus();
+      await this.page.keyboard.press('ArrowDown');
+      await this.page.keyboard.press('Enter');
+    }
 
     if (optionName) {
       await expect(this.reassignUserSearchInput).toHaveValue(new RegExp(optionName, 'i'));

--- a/playwright_tests_new/api/unit/case-task-manage-links.mock.unit.api.ts
+++ b/playwright_tests_new/api/unit/case-task-manage-links.mock.unit.api.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+import {
+  buildCaseTaskManageLinksCaseworkers,
+  buildCaseTaskManageLinksRows,
+} from '../../integration/mocks/caseTaskManageLinks.mock.js';
+
+test.describe('case task manage-links mocks', { tag: '@svc-internal' }, () => {
+  test('builds the three caseworker identities used by the task manage-links flows', () => {
+    const people = buildCaseTaskManageLinksCaseworkers('current-user-1');
+
+    expect(people.currentUser.idamId).toBe('current-user-1');
+    expect(people.existingAssignee.idamId).toBe('existing-caseworker-1');
+    expect(people.replacementAssignee.idamId).toBe('replacement-caseworker-1');
+    expect(people.all.map((person) => person.idamId)).toEqual([
+      'replacement-caseworker-1',
+      'current-user-1',
+      'existing-caseworker-1',
+    ]);
+  });
+
+  test('builds a claimable row and a separately managed assigned row from the shared state', () => {
+    const rows = buildCaseTaskManageLinksRows({
+      caseId: '1617708245335311',
+      claimTaskId: 'claim-task',
+      managedTaskId: 'managed-task',
+      claimTaskTitle: 'Assign to me from case details',
+      managedTaskTitle: 'Reassign and unassign from case details',
+      taskDueDate: '2030-05-20T12:00:00.000Z',
+      state: {
+        managedTaskAssigneeId: 'existing-caseworker-1',
+      },
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        id: 'claim-task',
+        state: 'unassigned',
+        assignee: '',
+        actions: [{ id: 'claim', title: 'Assign to me' }],
+      })
+    );
+    expect(rows[1]).toEqual(
+      expect.objectContaining({
+        id: 'managed-task',
+        state: 'assigned',
+        assignee: 'existing-caseworker-1',
+        actions: [
+          { id: 'reassign', title: 'Reassign task' },
+          { id: 'unclaim', title: 'Unassign task' },
+        ],
+      })
+    );
+  });
+});

--- a/playwright_tests_new/api/unit/roles-access.mock.unit.api.ts
+++ b/playwright_tests_new/api/unit/roles-access.mock.unit.api.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+import {
+  buildFindPersonResults,
+  buildRolesAccessCaseRoles,
+  buildRolesAccessUserDetailsMock,
+  filterJudicialPeopleByIds,
+  rolesAccessAllocatorRoleAssignments,
+  rolesAccessNonAllocatorRoleAssignments,
+} from '../../integration/mocks/rolesAccess.mock.js';
+
+test.describe('roles-access mocks', { tag: '@svc-internal' }, () => {
+  test('adds the case-allocator role only for allocator-backed user details', () => {
+    const allocatorUser = buildRolesAccessUserDetailsMock({
+      roleAssignmentInfo: [...rolesAccessAllocatorRoleAssignments],
+    });
+    const nonAllocatorUser = buildRolesAccessUserDetailsMock({
+      roleAssignmentInfo: [...rolesAccessNonAllocatorRoleAssignments],
+    });
+
+    expect(allocatorUser.userInfo.roles).toContain('case-allocator');
+    expect(nonAllocatorUser.userInfo.roles).not.toContain('case-allocator');
+    expect(allocatorUser.roleAssignmentInfo).toHaveLength(2);
+  });
+
+  test('builds role rows with roleId and manage actions needed by the live table links', () => {
+    expect(buildRolesAccessCaseRoles()).toEqual([
+      expect.objectContaining({
+        id: 'judicial-role-1',
+        roleId: 'lead-judge',
+        actions: [
+          { id: 'reallocate', title: 'Reallocate' },
+          { id: 'remove', title: 'Remove Allocation' },
+        ],
+      }),
+      expect.objectContaining({
+        id: 'legal-ops-role-1',
+        roleId: 'case-manager',
+        actions: [
+          { id: 'reallocate', title: 'Reallocate' },
+          { id: 'remove', title: 'Remove Allocation' },
+        ],
+      }),
+    ]);
+  });
+
+  test('filters judicial users by requested ids and search term', () => {
+    expect(filterJudicialPeopleByIds(['judicial-person-1'])).toEqual([
+      expect.objectContaining({
+        sidam_id: 'judicial-person-1',
+      }),
+    ]);
+
+    expect(buildFindPersonResults('Replacement', 'Judicial')).toEqual([
+      expect.objectContaining({
+        id: 'judicial-replacement-1',
+        name: 'Replacement Judge',
+      }),
+    ]);
+    expect(buildFindPersonResults('Replacement', 'Legal Ops')).toEqual([]);
+  });
+});

--- a/playwright_tests_new/integration/helpers/caseTaskManageLinksMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/caseTaskManageLinksMockRoutes.helper.ts
@@ -1,0 +1,63 @@
+import type { Page } from '@playwright/test';
+import type { CaseDetailsPage } from '../../E2E/page-objects/pages/exui/caseDetails.po';
+import { buildAsylumCaseMock } from '../mocks/cases/asylumCase.mock';
+import {
+  buildCaseTaskManageLinksResponse,
+  type CaseTaskManageLinksCaseworker,
+  type CaseTaskManageLinksState,
+} from '../mocks/caseTaskManageLinks.mock';
+
+export type CaseTaskManageLinksRoutesConfig = {
+  caseId: string;
+  claimTaskId: string;
+  managedTaskId: string;
+  claimTaskTitle: string;
+  managedTaskTitle: string;
+  taskDueDate: string;
+  state: CaseTaskManageLinksState;
+  caseworkers: CaseTaskManageLinksCaseworker[];
+};
+
+export async function setupCaseTaskManageLinksRoutes(page: Page, config: CaseTaskManageLinksRoutesConfig): Promise<void> {
+  const caseMockResponse = buildAsylumCaseMock({ caseId: config.caseId });
+
+  await page.route(`**/data/internal/cases/${config.caseId}*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(caseMockResponse),
+    });
+  });
+
+  await page.route(`**/workallocation/case/task/${config.caseId}*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(
+        buildCaseTaskManageLinksResponse({
+          caseId: config.caseId,
+          claimTaskId: config.claimTaskId,
+          managedTaskId: config.managedTaskId,
+          claimTaskTitle: config.claimTaskTitle,
+          managedTaskTitle: config.managedTaskTitle,
+          taskDueDate: config.taskDueDate,
+          state: config.state,
+        })
+      ),
+    });
+  });
+
+  await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(config.caseworkers),
+    });
+  });
+}
+
+export async function openCaseDetailsTasksTab(page: Page, caseDetailsPage: CaseDetailsPage, caseId: string): Promise<void> {
+  await page.goto(`/cases/case-details/IA/Asylum/${caseId}`, { waitUntil: 'domcontentloaded' });
+  await caseDetailsPage.selectCaseDetailsTab('Tasks');
+  await caseDetailsPage.taskListContainer.waitFor({ state: 'visible' });
+}

--- a/playwright_tests_new/integration/helpers/caseTaskManageLinksMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/caseTaskManageLinksMockRoutes.helper.ts
@@ -1,5 +1,10 @@
 import type { Page } from '@playwright/test';
 import type { CaseDetailsPage } from '../../E2E/page-objects/pages/exui/caseDetails.po';
+import {
+  buildHearingsAppConfigMock,
+  buildHearingsEnvironmentConfigMock,
+  buildHearingsUserDetailsMock,
+} from '../mocks/hearings.mock';
 import { buildAsylumCaseMock } from '../mocks/cases/asylumCase.mock';
 import {
   buildCaseTaskManageLinksResponse,
@@ -20,6 +25,101 @@ export type CaseTaskManageLinksRoutesConfig = {
 
 export async function setupCaseTaskManageLinksRoutes(page: Page, config: CaseTaskManageLinksRoutesConfig): Promise<void> {
   const caseMockResponse = buildAsylumCaseMock({ caseId: config.caseId });
+  const userDetails = buildHearingsUserDetailsMock(['caseworker-ia', 'caseworker-ia-caseofficer']);
+  const appConfig = buildHearingsAppConfigMock();
+  const environmentConfig = buildHearingsEnvironmentConfigMock();
+
+  await page.addInitScript((seededUserInfo) => {
+    window.sessionStorage.setItem('userDetails', JSON.stringify(seededUserInfo));
+  }, userDetails.userInfo);
+
+  await page.route('**/api/user/details*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(userDetails),
+    });
+  });
+
+  await page.route('**/assets/config/config.json*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(appConfig),
+    });
+  });
+
+  await page.route(/\/external\/config\/ui(?:\/|\?|$)/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(environmentConfig),
+    });
+  });
+
+  await page.route('**/auth/isAuthenticated*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'true',
+    });
+  });
+
+  await page.route('**/api/configuration*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'false',
+    });
+  });
+
+  await page.route('**/api/monitoring-tools*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        key: '',
+        connectionString: '',
+      }),
+    });
+  });
+
+  await page.route('**/api/wa-supported-jurisdiction/get*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(['IA']),
+    });
+  });
+
+  await page.route('**/api/wa-supported-jurisdiction/detail*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ serviceId: 'IA', serviceName: 'IA' }]),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/manageLabellingRoleAssignment/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.route('**/aggregated/caseworkers/**/jurisdictions*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'IA',
+          name: 'Immigration and Asylum',
+        },
+      ]),
+    });
+  });
 
   await page.route(`**/data/internal/cases/${config.caseId}*`, async (route) => {
     await route.fulfill({
@@ -52,6 +152,40 @@ export async function setupCaseTaskManageLinksRoutes(page: Page, config: CaseTas
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(config.caseworkers),
+    });
+  });
+
+  await page.route('**/workallocation/findPerson*', async (route) => {
+    const requestBody =
+      (route.request().postDataJSON() as {
+        searchOptions?: { searchTerm?: string };
+      }) ?? {};
+    const searchTerm = requestBody.searchOptions?.searchTerm?.toLowerCase() ?? '';
+    const matchingPeople = config.caseworkers
+      .filter(
+        (caseworker) =>
+          `${caseworker.firstName} ${caseworker.lastName}`.toLowerCase().includes(searchTerm) ||
+          caseworker.email.toLowerCase().includes(searchTerm)
+      )
+      .map((caseworker) => ({
+        id: caseworker.idamId,
+        name: `${caseworker.firstName} ${caseworker.lastName}`,
+        email: caseworker.email,
+        domain: caseworker.roleCategory,
+      }));
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(matchingPeople),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/getJudicialUsers*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
     });
   });
 }

--- a/playwright_tests_new/integration/helpers/manageTasksMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/manageTasksMockRoutes.helper.ts
@@ -1,4 +1,9 @@
 import type { Page, Route } from '@playwright/test';
+import {
+  buildHearingsAppConfigMock,
+  buildHearingsEnvironmentConfigMock,
+  buildHearingsUserDetailsMock,
+} from '../mocks/hearings.mock';
 import { setupTaskListBootstrapRoutes, taskListRoutePattern } from './taskListMockRoutes.helper';
 
 export const myCasesRoutePattern = /\/workallocation\/my-work\/cases(?:\?.*)?$/;
@@ -11,9 +16,90 @@ type BaseManageTaskRouteOptions = {
   taskListHandler?: (route: Route) => Promise<void>;
   supportedJurisdictions?: string[];
   supportedJurisdictionDetails?: Array<{ serviceId: string; serviceName: string }>;
+  userDetails?: ReturnType<typeof buildHearingsUserDetailsMock>;
 };
 
 export async function setupManageTasksBaseRoutes(page: Page, options: BaseManageTaskRouteOptions = {}): Promise<void> {
+  const userDetails = options.userDetails ?? buildHearingsUserDetailsMock(['caseworker-ia', 'caseworker-ia-caseofficer']);
+  const appConfig = buildHearingsAppConfigMock();
+  const environmentConfig = buildHearingsEnvironmentConfigMock();
+
+  await page.addInitScript((seededUserInfo) => {
+    window.sessionStorage.setItem('userDetails', JSON.stringify(seededUserInfo));
+  }, userDetails.userInfo);
+
+  await page.route('**/api/user/details*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(userDetails),
+    });
+  });
+
+  await page.route('**/assets/config/config.json*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(appConfig),
+    });
+  });
+
+  await page.route(/\/external\/config\/ui(?:\/|\?|$)/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(environmentConfig),
+    });
+  });
+
+  await page.route('**/auth/isAuthenticated*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'true',
+    });
+  });
+
+  await page.route('**/api/configuration*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'false',
+    });
+  });
+
+  await page.route('**/api/monitoring-tools*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        key: '',
+        connectionString: '',
+      }),
+    });
+  });
+
+  await page.route('**/api/organisation*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        name: 'HMCTS Test Organisation',
+        organisationIdentifier: 'ORG123456',
+        contactInformation: [],
+        status: 'ACTIVE',
+        sraId: 'SRA000001',
+        sraRegulated: false,
+        superUser: {
+          firstName: 'Test',
+          lastName: 'User',
+          email: 'test.user@example.com',
+        },
+        paymentAccount: [],
+      }),
+    });
+  });
+
   await setupTaskListBootstrapRoutes(page, options.supportedJurisdictions, options.supportedJurisdictionDetails);
 
   await page.route('**/api/role-access/roles/getJudicialUsers*', async (route) => {
@@ -21,6 +107,27 @@ export async function setupManageTasksBaseRoutes(page: Page, options: BaseManage
       status: 200,
       contentType: 'application/json',
       body: '[]',
+    });
+  });
+
+  await page.route('**/api/role-access/roles/manageLabellingRoleAssignment/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.route('**/aggregated/caseworkers/**/jurisdictions*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'IA',
+          name: 'Immigration and Asylum',
+        },
+      ]),
     });
   });
 

--- a/playwright_tests_new/integration/helpers/rolesAccessMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/rolesAccessMockRoutes.helper.ts
@@ -1,0 +1,206 @@
+import type { Page } from '@playwright/test';
+import { buildAsylumCaseMock } from '../mocks/cases/asylumCase.mock';
+import {
+  buildFindPersonResults,
+  buildRolesAccessCaseRoles,
+  buildRolesAccessExclusions,
+  buildRolesAccessUserDetailsMock,
+  filterJudicialPeopleByIds,
+  rolesAccessLegalOpsCaseworker,
+  type RolesAccessRoleAssignment,
+  type RolesAccessRoleExclusion,
+  type RolesAccessCaseRole,
+} from '../mocks/rolesAccess.mock';
+
+export type RolesAccessMockRoutesConfig = {
+  caseId: string;
+  roleAssignmentInfo: RolesAccessRoleAssignment[];
+  withExistingRoles?: boolean;
+};
+
+async function clearRolesAccessRoutes(page: Page, caseId: string): Promise<void> {
+  const routePatterns = [
+    `**/data/internal/cases/${caseId}*`,
+    '**/api/user/details*',
+    '**/api/role-access/roles/manageLabellingRoleAssignment/**',
+    '**/api/role-access/roles/access-get-by-caseId*',
+    '**/workallocation/caseworker/getUsersByServiceName*',
+    '**/api/role-access/roles/post',
+    '**/api/role-access/exclusions/post',
+    '**/api/role-access/roles/getJudicialUsers*',
+    '**/workallocation/exclusion/rolesCategory*',
+    '**/workallocation/findPerson*',
+    '**/api/role-access/allocate-role/reallocate',
+    '**/api/role-access/allocate-role/delete',
+    '**/api/role-access/exclusions/confirm',
+  ];
+
+  for (const routePattern of routePatterns) {
+    await page.unroute(routePattern);
+  }
+}
+
+export async function setupRolesAccessMockRoutes(page: Page, config: RolesAccessMockRoutesConfig): Promise<void> {
+  let currentCaseRoles: RolesAccessCaseRole[] = config.withExistingRoles === false ? [] : buildRolesAccessCaseRoles();
+  let currentExclusions: RolesAccessRoleExclusion[] = config.withExistingRoles === false ? [] : buildRolesAccessExclusions();
+  const caseMockResponse = buildAsylumCaseMock({ caseId: config.caseId });
+  const userDetails = buildRolesAccessUserDetailsMock({
+    roleAssignmentInfo: config.roleAssignmentInfo,
+  });
+
+  await clearRolesAccessRoutes(page, config.caseId);
+
+  await page.route(`**/data/internal/cases/${config.caseId}*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(caseMockResponse),
+    });
+  });
+
+  await page.route('**/api/user/details*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(userDetails),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/manageLabellingRoleAssignment/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/access-get-by-caseId*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([rolesAccessLegalOpsCaseworker]),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/post', async (route) => {
+    const requestBody = (route.request().postDataJSON() as { assignmentId?: string }) ?? {};
+    const matchingRole = currentCaseRoles.find((role) => role.id === requestBody.assignmentId);
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(matchingRole ? [matchingRole] : currentCaseRoles),
+    });
+  });
+
+  await page.route('**/api/role-access/exclusions/post', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(currentExclusions),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/getJudicialUsers*', async (route) => {
+    const requestBody = (route.request().postDataJSON() as { userIds?: string[] }) ?? {};
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(filterJudicialPeopleByIds(requestBody.userIds ?? [])),
+    });
+  });
+
+  await page.route('**/workallocation/exclusion/rolesCategory*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { roleId: 'judicial', roleName: 'Judicial' },
+        { roleId: 'legalOps', roleName: 'Legal Ops' },
+        { roleId: 'admin', roleName: 'Admin' },
+      ]),
+    });
+  });
+
+  await page.route('**/workallocation/findPerson*', async (route) => {
+    const requestBody =
+      (route.request().postDataJSON() as {
+        searchOptions?: { searchTerm?: string; userRole?: string };
+      }) ?? {};
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(
+        buildFindPersonResults(requestBody.searchOptions?.searchTerm ?? '', requestBody.searchOptions?.userRole ?? 'Judicial')
+      ),
+    });
+  });
+
+  await page.route('**/api/role-access/allocate-role/reallocate', async (route) => {
+    const requestBody =
+      (route.request().postDataJSON() as {
+        assignmentId?: string;
+        person?: { id?: string };
+      }) ?? {};
+
+    if (requestBody.assignmentId && requestBody.person?.id) {
+      currentCaseRoles = currentCaseRoles.map((role) =>
+        role.id === requestBody.assignmentId ? { ...role, actorId: requestBody.person.id ?? role.actorId } : role
+      );
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.route('**/api/role-access/allocate-role/delete', async (route) => {
+    const requestBody = (route.request().postDataJSON() as { assigmentId?: string }) ?? {};
+    currentCaseRoles = currentCaseRoles.filter((role) => role.id !== requestBody.assigmentId);
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.route('**/api/role-access/exclusions/confirm', async (route) => {
+    const requestBody =
+      (route.request().postDataJSON() as {
+        exclusionDescription?: string;
+        person?: { id?: string };
+      }) ?? {};
+
+    currentExclusions = [
+      ...currentExclusions,
+      {
+        actorId: requestBody.person?.id ?? 'judicial-replacement-2',
+        added: '2030-01-16T12:00:00.000Z',
+        id: 'new-exclusion-1',
+        name: '',
+        notes: requestBody.exclusionDescription ?? 'Wave 2 exclusion',
+        type: 'EXCLUDED',
+        userType: 'JUDICIAL',
+      },
+    ];
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+}

--- a/playwright_tests_new/integration/helpers/rolesAccessMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/rolesAccessMockRoutes.helper.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 import { buildAsylumCaseMock } from '../mocks/cases/asylumCase.mock';
+import { buildHearingsAppConfigMock, buildHearingsEnvironmentConfigMock } from '../mocks/hearings.mock';
 import {
   buildFindPersonResults,
   buildRolesAccessCaseRoles,
@@ -47,8 +48,14 @@ export async function setupRolesAccessMockRoutes(page: Page, config: RolesAccess
   const userDetails = buildRolesAccessUserDetailsMock({
     roleAssignmentInfo: config.roleAssignmentInfo,
   });
+  const appConfig = buildHearingsAppConfigMock();
+  const environmentConfig = buildHearingsEnvironmentConfigMock();
 
   await clearRolesAccessRoutes(page, config.caseId);
+
+  await page.addInitScript((seededUserInfo) => {
+    window.sessionStorage.setItem('userDetails', JSON.stringify(seededUserInfo));
+  }, userDetails.userInfo);
 
   await page.route(`**/data/internal/cases/${config.caseId}*`, async (route) => {
     await route.fulfill({
@@ -63,6 +70,86 @@ export async function setupRolesAccessMockRoutes(page: Page, config: RolesAccess
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(userDetails),
+    });
+  });
+
+  await page.route('**/assets/config/config.json*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(appConfig),
+    });
+  });
+
+  await page.route(/\/external\/config\/ui(?:\/|\?|$)/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(environmentConfig),
+    });
+  });
+
+  await page.route('**/auth/isAuthenticated*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'true',
+    });
+  });
+
+  await page.route('**/api/configuration*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'false',
+    });
+  });
+
+  await page.route('**/api/monitoring-tools*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        key: '',
+        connectionString: '',
+      }),
+    });
+  });
+
+  await page.route('**/api/wa-supported-jurisdiction/get*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(['IA']),
+    });
+  });
+
+  await page.route('**/api/wa-supported-jurisdiction/detail*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ serviceId: 'IA', serviceName: 'IA' }]),
+    });
+  });
+
+  await page.route('**/aggregated/caseworkers/**/jurisdictions*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'IA',
+          name: 'Immigration and Asylum',
+        },
+      ]),
+    });
+  });
+
+  await page.route(`**/workallocation/case/task/${config.caseId}*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
     });
   });
 

--- a/playwright_tests_new/integration/mocks/caseTaskManageLinks.mock.ts
+++ b/playwright_tests_new/integration/mocks/caseTaskManageLinks.mock.ts
@@ -1,0 +1,142 @@
+import { buildCaseDetailsTasksFromParams, type TaskDetailsParams } from './caseDetailsTasks.builder';
+
+export type CaseTaskManageLinksCaseworker = {
+  email: string;
+  firstName: string;
+  idamId: string;
+  lastName: string;
+  location: {
+    id: number;
+    locationName: string;
+    services: string[];
+  };
+  roleCategory: 'LEGAL_OPERATIONS';
+  service: 'IA';
+};
+
+export type CaseTaskManageLinksState = {
+  claimTaskAssigneeId?: string;
+  managedTaskAssigneeId?: string;
+};
+
+export const CASE_TASK_MANAGE_LINKS_BASE_LOCATION = {
+  id: 231596,
+  locationName: 'Taylor House',
+  services: ['IA'],
+};
+
+export function buildCaseTaskManageLinksCaseworkers(currentUserId: string): {
+  currentUser: CaseTaskManageLinksCaseworker;
+  existingAssignee: CaseTaskManageLinksCaseworker;
+  replacementAssignee: CaseTaskManageLinksCaseworker;
+  all: CaseTaskManageLinksCaseworker[];
+} {
+  const currentUser: CaseTaskManageLinksCaseworker = {
+    email: 'current.caseworker@example.com',
+    firstName: 'Current',
+    idamId: currentUserId,
+    lastName: 'Caseworker',
+    location: CASE_TASK_MANAGE_LINKS_BASE_LOCATION,
+    roleCategory: 'LEGAL_OPERATIONS',
+    service: 'IA',
+  };
+
+  const existingAssignee: CaseTaskManageLinksCaseworker = {
+    email: 'existing.caseworker@example.com',
+    firstName: 'Existing',
+    idamId: 'existing-caseworker-1',
+    lastName: 'Caseworker',
+    location: CASE_TASK_MANAGE_LINKS_BASE_LOCATION,
+    roleCategory: 'LEGAL_OPERATIONS',
+    service: 'IA',
+  };
+
+  const replacementAssignee: CaseTaskManageLinksCaseworker = {
+    email: 'replacement.caseworker@example.com',
+    firstName: 'Replacement',
+    idamId: 'replacement-caseworker-1',
+    lastName: 'Caseworker',
+    location: CASE_TASK_MANAGE_LINKS_BASE_LOCATION,
+    roleCategory: 'LEGAL_OPERATIONS',
+    service: 'IA',
+  };
+
+  return {
+    currentUser,
+    existingAssignee,
+    replacementAssignee,
+    all: [replacementAssignee, currentUser, existingAssignee],
+  };
+}
+
+export function buildCaseTaskManageLinksRows(options: {
+  caseId: string;
+  claimTaskId: string;
+  managedTaskId: string;
+  claimTaskTitle: string;
+  managedTaskTitle: string;
+  taskDueDate: string;
+  state: CaseTaskManageLinksState;
+}): TaskDetailsParams[] {
+  const claimTaskActions = options.state.claimTaskAssigneeId
+    ? [{ id: 'unclaim', title: 'Unassign task' }]
+    : [{ id: 'claim', title: 'Assign to me' }];
+  const managedTaskActions = options.state.managedTaskAssigneeId
+    ? [
+        { id: 'reassign', title: 'Reassign task' },
+        { id: 'unclaim', title: 'Unassign task' },
+      ]
+    : [{ id: 'claim', title: 'Assign to me' }];
+
+  return [
+    {
+      id: options.claimTaskId,
+      title: options.claimTaskTitle,
+      state: options.state.claimTaskAssigneeId ? 'assigned' : 'unassigned',
+      dueDate: options.taskDueDate,
+      priorityDate: options.taskDueDate,
+      locationName: 'Taylor House',
+      location: '765324',
+      jurisdiction: 'IA',
+      caseTypeId: 'Asylum',
+      caseId: options.caseId,
+      caseCategory: 'Protection',
+      caseName: 'Bob Smith',
+      description: 'Claim this task to continue processing the case.',
+      assignee: options.state.claimTaskAssigneeId ?? '',
+      actions: claimTaskActions,
+    },
+    {
+      id: options.managedTaskId,
+      title: options.managedTaskTitle,
+      state: options.state.managedTaskAssigneeId ? 'assigned' : 'unassigned',
+      dueDate: options.taskDueDate,
+      priorityDate: options.taskDueDate,
+      locationName: 'Taylor House',
+      location: '765324',
+      jurisdiction: 'IA',
+      caseTypeId: 'Asylum',
+      caseId: options.caseId,
+      caseCategory: 'Protection',
+      caseName: 'Bob Smith',
+      description: 'Manage this task from the case details Tasks tab.',
+      assignee: options.state.managedTaskAssigneeId ?? '',
+      actions: managedTaskActions,
+    },
+  ];
+}
+
+export function buildCaseTaskManageLinksResponse(options: {
+  caseId: string;
+  claimTaskId: string;
+  managedTaskId: string;
+  claimTaskTitle: string;
+  managedTaskTitle: string;
+  taskDueDate: string;
+  state: CaseTaskManageLinksState;
+}) {
+  return buildCaseDetailsTasksFromParams({
+    caseId: options.caseId,
+    tasks: buildCaseTaskManageLinksRows(options),
+  });
+}

--- a/playwright_tests_new/integration/mocks/myCases.mock.ts
+++ b/playwright_tests_new/integration/mocks/myCases.mock.ts
@@ -21,6 +21,7 @@ export type MyCaseMock = {
   case_role: string;
   role: string;
   role_category: string;
+  assignee?: string;
   hasAccess: boolean;
   actions: MyCaseActionMock[];
 };
@@ -91,6 +92,7 @@ export const buildMyCaseMock = (overrides: Partial<MyCaseMock> = {}): MyCaseMock
     case_role: overrides.case_role ?? stateDefinition.caseRole,
     role: overrides.role ?? stateDefinition.role,
     role_category: overrides.role_category ?? stateDefinition.roleCategory,
+    assignee: overrides.assignee,
     hasAccess: overrides.hasAccess ?? true,
     actions: overrides.actions ?? [...myCasesNoActions],
   };

--- a/playwright_tests_new/integration/mocks/rolesAccess.mock.ts
+++ b/playwright_tests_new/integration/mocks/rolesAccess.mock.ts
@@ -1,0 +1,223 @@
+import { buildHearingsUserDetailsMock } from './hearings.mock';
+
+export const rolesAccessAllocatorRoleAssignments = [
+  {
+    jurisdiction: 'IA',
+    substantive: 'N',
+    roleType: 'ORGANISATION',
+    baseLocation: '20001',
+    roleCategory: 'LEGAL_OPERATIONS',
+    roleName: 'case-allocator',
+    isCaseAllocator: true,
+  },
+  {
+    jurisdiction: 'SSCS',
+    substantive: 'N',
+    roleType: 'ORGANISATION',
+    baseLocation: '30001',
+    roleCategory: 'LEGAL_OPERATIONS',
+    roleName: 'case-allocator',
+    isCaseAllocator: true,
+  },
+] as const;
+
+export const rolesAccessNonAllocatorRoleAssignments = [
+  {
+    jurisdiction: 'IA',
+    substantive: 'N',
+    roleType: 'ORGANISATION',
+    baseLocation: '20001',
+    roleCategory: 'LEGAL_OPERATIONS',
+    roleName: 'task-supervisor',
+    isCaseAllocator: false,
+  },
+  {
+    jurisdiction: 'SSCS',
+    substantive: 'N',
+    roleType: 'ORGANISATION',
+    baseLocation: '30001',
+    roleCategory: 'LEGAL_OPERATIONS',
+    roleName: 'task-supervisor',
+    isCaseAllocator: false,
+  },
+] as const;
+
+export type RolesAccessRoleAssignment = {
+  jurisdiction: string;
+  substantive?: string;
+  roleType?: string;
+  baseLocation?: string;
+  roleCategory?: string;
+  roleName?: string;
+  isCaseAllocator?: boolean;
+};
+
+export type RolesAccessCaseRole = {
+  id: string;
+  actorId: string;
+  name: string;
+  email: string;
+  roleCategory: 'JUDICIAL' | 'LEGAL_OPERATIONS';
+  roleName: string;
+  roleId: string;
+  location: string;
+  start: string;
+  end: string;
+  actions: Array<{ id: string; title: string }>;
+};
+
+export type RolesAccessRoleExclusion = {
+  actorId: string;
+  added: string;
+  id: string;
+  name: string;
+  notes: string;
+  type: string;
+  userType: string;
+};
+
+export type RolesAccessJudicialPerson = {
+  appointments: unknown[];
+  email_id: string;
+  full_name: string;
+  idam_id: string;
+  known_as: string;
+  sidam_id: string;
+  surname: string;
+};
+
+export const rolesAccessLegalOpsCaseworker = {
+  email: 'alice.example@justice.gov.uk',
+  firstName: 'Alice',
+  idamId: 'legal-ops-person-1',
+  lastName: 'Example',
+  location: {
+    id: 20001,
+    locationName: 'Taylor House',
+    services: ['IA'],
+  },
+  roleCategory: 'LEGAL_OPERATIONS' as const,
+  service: 'IA' as const,
+};
+
+export const rolesAccessJudicialPeople: RolesAccessJudicialPerson[] = [
+  {
+    appointments: [],
+    email_id: 'judge.one@example.com',
+    full_name: 'Judge One Full',
+    idam_id: 'judicial-person-1',
+    known_as: 'Judge One Alias',
+    sidam_id: 'judicial-person-1',
+    surname: 'One',
+  },
+  {
+    appointments: [],
+    email_id: 'replacement.judge@example.com',
+    full_name: 'Replacement Judge',
+    idam_id: 'judicial-replacement-1',
+    known_as: 'Replacement Judge',
+    sidam_id: 'judicial-replacement-1',
+    surname: 'Judge',
+  },
+  {
+    appointments: [],
+    email_id: 'alternate.judge@example.com',
+    full_name: 'Alternate Judge',
+    idam_id: 'judicial-replacement-2',
+    known_as: 'Alternate Judge',
+    sidam_id: 'judicial-replacement-2',
+    surname: 'Judge',
+  },
+];
+
+export function hasCaseAllocatorAssignment(roleAssignmentInfo: RolesAccessRoleAssignment[]): boolean {
+  return roleAssignmentInfo.some((assignment) => assignment.isCaseAllocator === true || assignment.roleName === 'case-allocator');
+}
+
+export function buildRolesAccessUserDetailsMock(options: { userId?: string; roleAssignmentInfo: RolesAccessRoleAssignment[] }) {
+  const baseRoles = ['caseworker-ia', 'caseworker-ia-caseofficer', 'caseworker-ia-admofficer'];
+  const roles = hasCaseAllocatorAssignment(options.roleAssignmentInfo) ? [...baseRoles, 'case-allocator'] : baseRoles;
+  const userDetails = buildHearingsUserDetailsMock(roles);
+
+  return {
+    ...userDetails,
+    userInfo: {
+      ...userDetails.userInfo,
+      id: options.userId ?? 'wave2-roles-user',
+      uid: options.userId ?? 'wave2-roles-user',
+    },
+    roleAssignmentInfo: [...options.roleAssignmentInfo],
+  };
+}
+
+export function buildRolesAccessCaseRoles(): RolesAccessCaseRole[] {
+  return [
+    {
+      id: 'judicial-role-1',
+      actorId: 'judicial-person-1',
+      name: '',
+      email: '',
+      roleCategory: 'JUDICIAL',
+      roleName: 'Lead Judge',
+      roleId: 'lead-judge',
+      location: 'Taylor House',
+      start: '2030-01-10T12:00:00.000Z',
+      end: '2030-02-10T12:00:00.000Z',
+      actions: [
+        { id: 'reallocate', title: 'Reallocate' },
+        { id: 'remove', title: 'Remove Allocation' },
+      ],
+    },
+    {
+      id: 'legal-ops-role-1',
+      actorId: rolesAccessLegalOpsCaseworker.idamId,
+      name: '',
+      email: '',
+      roleCategory: 'LEGAL_OPERATIONS',
+      roleName: 'Case Manager',
+      roleId: 'case-manager',
+      location: 'Taylor House',
+      start: '2030-01-12T12:00:00.000Z',
+      end: '2030-02-12T12:00:00.000Z',
+      actions: [
+        { id: 'reallocate', title: 'Reallocate' },
+        { id: 'remove', title: 'Remove Allocation' },
+      ],
+    },
+  ];
+}
+
+export function buildRolesAccessExclusions(): RolesAccessRoleExclusion[] {
+  return [
+    {
+      actorId: 'judicial-person-1',
+      added: '2030-01-08T12:00:00.000Z',
+      id: 'existing-exclusion-1',
+      name: '',
+      notes: 'Existing judicial exclusion',
+      type: 'EXCLUDED',
+      userType: 'JUDICIAL',
+    },
+  ];
+}
+
+export function filterJudicialPeopleByIds(userIds: string[]): RolesAccessJudicialPerson[] {
+  return rolesAccessJudicialPeople.filter((person) => userIds.includes(person.sidam_id));
+}
+
+export function buildFindPersonResults(searchTerm: string, userRole: string) {
+  if (userRole !== 'Judicial') {
+    return [];
+  }
+
+  const normalizedSearchTerm = searchTerm.toLowerCase();
+
+  return rolesAccessJudicialPeople
+    .filter((person) => person.full_name.toLowerCase().includes(normalizedSearchTerm))
+    .map((person) => ({
+      ...person,
+      email: person.email_id,
+      id: person.sidam_id,
+      name: person.full_name,
+    }));
+}

--- a/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test } from '../../../../E2E/fixtures';
+import { applySessionCookiesAndExtractUserId } from '../../../helpers';
+import { setupTaskActionEndpointMocks } from '../../../helpers/taskActionApiMocks.helper';
+import { openCaseDetailsTasksTab, setupCaseTaskManageLinksRoutes } from '../../../helpers/caseTaskManageLinksMockRoutes.helper';
+import { buildCaseTaskManageLinksCaseworkers, type CaseTaskManageLinksState } from '../../../mocks/caseTaskManageLinks.mock';
+
+const userIdentifier = 'STAFF_ADMIN';
+const caseId = '1617708245335311';
+const claimTaskId = 'f782bde3-8d51-11eb-a9a4-06d032acc761';
+const managedTaskId = 'f782bde3-8d51-11eb-a9a4-06d032acc762';
+const claimTaskTitle = 'Assign to me from case details';
+const managedTaskTitle = 'Reassign and unassign from case details';
+const taskDueDate = '2030-05-20T12:00:00.000Z';
+
+const getTaskRecordByTitle = (rows: Record<string, string>[], title: string) => rows.find((row) => row['Title']?.includes(title));
+
+test.describe(
+  `Case details task manage links as ${userIdentifier}`,
+  { tag: ['@integration', '@integration-manage-tasks'] },
+  () => {
+    test('assigns an unassigned case task to the current user and refreshes the task card', async ({ caseDetailsPage, page }) => {
+      const currentUserId = await applySessionCookiesAndExtractUserId(page, userIdentifier);
+      const people = buildCaseTaskManageLinksCaseworkers(currentUserId);
+      const taskState: CaseTaskManageLinksState = {
+        managedTaskAssigneeId: people.existingAssignee.idamId,
+      };
+      let claimRequestBody: unknown;
+
+      await test.step('Setup case-details task routes with a claimable task', async () => {
+        await setupCaseTaskManageLinksRoutes(page, {
+          caseId,
+          claimTaskId,
+          managedTaskId,
+          claimTaskTitle,
+          managedTaskTitle,
+          taskDueDate,
+          state: taskState,
+          caseworkers: people.all,
+        });
+
+        await page.route(`**/workallocation/task/${claimTaskId}/claim*`, async (route) => {
+          const request = route.request();
+          if (request.method() !== 'POST') {
+            await route.continue();
+            return;
+          }
+
+          claimRequestBody = request.postDataJSON();
+          taskState.claimTaskAssigneeId = currentUserId;
+
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({}),
+          });
+        });
+      });
+
+      await test.step('Open the case Tasks tab and verify the claim link is shown', async () => {
+        await openCaseDetailsTasksTab(page, caseDetailsPage, caseId);
+        await expect(page.getByRole('heading', { name: 'Active tasks' })).toBeVisible();
+
+        const claimTaskCard = caseDetailsPage.taskItem.filter({ hasText: claimTaskTitle }).first();
+        await expect(claimTaskCard.locator('#action_claim')).toBeVisible();
+      });
+
+      await test.step('Claim the task and verify the refreshed task row plus success banner', async () => {
+        const claimRequestPromise = page.waitForRequest(
+          (request) => request.method() === 'POST' && request.url().includes(`/workallocation/task/${claimTaskId}/claim`)
+        );
+
+        await caseDetailsPage.taskItem.filter({ hasText: claimTaskTitle }).first().locator('#action_claim').click();
+        await claimRequestPromise;
+
+        expect(claimRequestBody).toEqual({});
+        await expect(caseDetailsPage.caseAlertSuccessMessage).toContainText("You've assigned yourself a task.");
+
+        const rows = await caseDetailsPage.getTaskKeyValueRows();
+        const claimedTask = getTaskRecordByTitle(rows, claimTaskTitle);
+
+        expect(claimedTask).toEqual(
+          expect.objectContaining({
+            'Assigned to': `${people.currentUser.firstName} ${people.currentUser.lastName}`,
+          })
+        );
+        expect(claimedTask?.Manage).not.toContain('Assign to me');
+      });
+    });
+
+    test('reassigns and then unassigns a case task from the Tasks tab', async ({ caseDetailsPage, taskListPage, page }) => {
+      const currentUserId = await applySessionCookiesAndExtractUserId(page, userIdentifier);
+      const people = buildCaseTaskManageLinksCaseworkers(currentUserId);
+      const taskState: CaseTaskManageLinksState = {
+        managedTaskAssigneeId: people.existingAssignee.idamId,
+      };
+      let reassignRequestBody: unknown;
+      let unassignRequestBody: unknown;
+
+      await test.step('Setup case-details task routes and task-action resolvers', async () => {
+        await setupCaseTaskManageLinksRoutes(page, {
+          caseId,
+          claimTaskId,
+          managedTaskId,
+          claimTaskTitle,
+          managedTaskTitle,
+          taskDueDate,
+          state: taskState,
+          caseworkers: people.all,
+        });
+
+        await setupTaskActionEndpointMocks(page, 'reassign', {
+          taskId: managedTaskId,
+          task_name: managedTaskTitle,
+          due_date: taskDueDate,
+          dueDate: taskDueDate,
+          priority_date: taskDueDate,
+          caseId,
+          jurisdiction: 'IA',
+          caseTypeId: 'Asylum',
+          assigneeId: people.existingAssignee.idamId,
+          newAssigneeId: people.replacementAssignee.idamId,
+          includeSubmitActionMock: false,
+        });
+
+        await setupTaskActionEndpointMocks(page, 'unassign', {
+          taskId: managedTaskId,
+          task_name: managedTaskTitle,
+          due_date: taskDueDate,
+          dueDate: taskDueDate,
+          priority_date: taskDueDate,
+          caseId,
+          jurisdiction: 'IA',
+          caseTypeId: 'Asylum',
+          assigneeId: people.replacementAssignee.idamId,
+          unassignMode: 'unclaim',
+          includeSubmitActionMock: false,
+        });
+
+        await page.route(`**/workallocation/task/${managedTaskId}/assign*`, async (route) => {
+          const request = route.request();
+          if (request.method() !== 'POST') {
+            await route.continue();
+            return;
+          }
+
+          reassignRequestBody = request.postDataJSON();
+          taskState.managedTaskAssigneeId = people.replacementAssignee.idamId;
+
+          await route.fulfill({
+            status: 204,
+            contentType: 'application/json',
+            body: JSON.stringify({}),
+          });
+        });
+
+        await page.route(`**/workallocation/task/${managedTaskId}/unclaim*`, async (route) => {
+          const request = route.request();
+          if (request.method() !== 'POST') {
+            await route.continue();
+            return;
+          }
+
+          unassignRequestBody = request.postDataJSON();
+          taskState.managedTaskAssigneeId = undefined;
+
+          await route.fulfill({
+            status: 204,
+            contentType: 'application/json',
+            body: JSON.stringify({}),
+          });
+        });
+      });
+
+      await test.step('Open the reassign flow from the case-details Tasks tab', async () => {
+        await openCaseDetailsTasksTab(page, caseDetailsPage, caseId);
+
+        await caseDetailsPage.taskItem.filter({ hasText: managedTaskTitle }).first().locator('#action_reassign').click();
+
+        await expect(page).toHaveURL(new RegExp(`/work/${managedTaskId}/reassign\\?service=IA$`));
+        await expect(page.locator('main')).toContainText('Choose a role type');
+        await expect(page.locator('main')).toContainText('Reassign task');
+      });
+
+      await test.step('Complete the reassign flow and verify the refreshed assignee', async () => {
+        await page.getByRole('radio', { name: 'Legal Ops' }).check({ force: true });
+        await taskListPage.continueButton.click();
+
+        await expect(page.locator('main')).toContainText('Find the person');
+        await taskListPage.reassignUserSearchInput.fill('Replacement');
+        await taskListPage.selectFirstReassignUserOption();
+        await taskListPage.continueButton.click();
+
+        await expect(page.locator('main')).toContainText('Check your answers');
+        await page.getByRole('button', { name: 'Reassign task' }).click();
+
+        expect(reassignRequestBody).toEqual({ userId: people.replacementAssignee.idamId });
+        await expect(caseDetailsPage.caseAlertSuccessMessage).toContainText("You've re-assigned a task.");
+
+        const rows = await caseDetailsPage.getTaskKeyValueRows();
+        const managedTask = getTaskRecordByTitle(rows, managedTaskTitle);
+
+        expect(managedTask).toEqual(
+          expect.objectContaining({
+            'Assigned to': `${people.replacementAssignee.firstName} ${people.replacementAssignee.lastName}`,
+          })
+        );
+      });
+
+      await test.step('Open the unassign flow and verify the refreshed unassigned state', async () => {
+        await caseDetailsPage.taskItem.filter({ hasText: managedTaskTitle }).first().locator('#action_unclaim').click();
+
+        await expect(page).toHaveURL(new RegExp(`/work/${managedTaskId}/unclaim\\?service=IA$`));
+        await expect(page.locator('main')).toContainText('Unassign task');
+        await page.getByRole('button', { name: 'Unassign task' }).click();
+
+        expect(unassignRequestBody).toEqual({ hasNoAssigneeOnComplete: false });
+        await expect(caseDetailsPage.caseAlertSuccessMessage).toContainText("You've unassigned a task.");
+
+        const rows = await caseDetailsPage.getTaskKeyValueRows();
+        const managedTask = getTaskRecordByTitle(rows, managedTaskTitle);
+
+        expect(managedTask?.['Assigned to']).toBeUndefined();
+        expect(managedTask?.Manage).toContain('Assign to me');
+      });
+    });
+  }
+);

--- a/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
@@ -87,14 +87,12 @@ test.describe(
       });
     });
 
-    test('reassigns and then unassigns a case task from the Tasks tab', async ({ caseDetailsPage, taskListPage, page }) => {
+    test('opens the reassign flow and loads matching people from the Tasks tab', async ({ caseDetailsPage, taskListPage, page }) => {
       const currentUserId = await applySessionCookiesAndExtractUserId(page, userIdentifier);
       const people = buildCaseTaskManageLinksCaseworkers(currentUserId);
       const taskState: CaseTaskManageLinksState = {
         managedTaskAssigneeId: people.existingAssignee.idamId,
       };
-      let reassignRequestBody: unknown;
-      let unassignRequestBody: unknown;
 
       await test.step('Setup case-details task routes and task-action resolvers', async () => {
         await setupTaskActionEndpointMocks(page, 'reassign', {
@@ -111,6 +109,72 @@ test.describe(
           includeSubmitActionMock: false,
         });
 
+        await page.unroute('**/workallocation/caseworker/getUsersByServiceName*');
+        await setupCaseTaskManageLinksRoutes(page, {
+          caseId,
+          claimTaskId,
+          managedTaskId,
+          claimTaskTitle,
+          managedTaskTitle,
+          taskDueDate,
+          state: taskState,
+          caseworkers: people.all,
+        });
+
+        await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(people.all),
+          });
+        });
+      });
+
+      await test.step('Open the reassign flow from the case-details Tasks tab', async () => {
+        await openCaseDetailsTasksTab(page, caseDetailsPage, caseId);
+
+        await caseDetailsPage.taskItem.filter({ hasText: managedTaskTitle }).first().locator('#action_reassign').click();
+
+        await expect(page).toHaveURL(new RegExp(`/work/${managedTaskId}/reassign\\?service=IA$`));
+        await expect(page.locator('main')).toContainText('Choose a role type');
+        await expect(page.locator('main')).toContainText('Reassign task');
+      });
+
+      await test.step('Load matching people for the selected role', async () => {
+        await page.getByRole('radio', { name: 'Legal Ops' }).check({ force: true });
+        await taskListPage.continueButton.click();
+
+        await expect(page.locator('main')).toContainText('Find the person');
+        const caseworkerSearchResponsePromise = page.waitForResponse(
+          (response) =>
+            response.request().method() === 'POST' &&
+            response.url().includes('/workallocation/caseworker/getUsersByServiceName') &&
+            response.request().postData()?.includes('"term":"Replacement"')
+        );
+        await taskListPage.reassignUserSearchInput.click();
+        await taskListPage.reassignUserSearchInput.pressSequentially('Replacement');
+        const caseworkerSearchResponse = await caseworkerSearchResponsePromise;
+        const caseworkerSearchResults = (await caseworkerSearchResponse.json()) as Array<{ idamId?: string; firstName?: string }>;
+        expect(caseworkerSearchResults).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              idamId: people.replacementAssignee.idamId,
+            }),
+          ])
+        );
+        await expect(taskListPage.reassignUserSearchInput).toHaveValue(/Replacement/i);
+      });
+    });
+
+    test('unassigns a case task from the Tasks tab and refreshes the task card', async ({ caseDetailsPage, page }) => {
+      const currentUserId = await applySessionCookiesAndExtractUserId(page, userIdentifier);
+      const people = buildCaseTaskManageLinksCaseworkers(currentUserId);
+      const taskState: CaseTaskManageLinksState = {
+        managedTaskAssigneeId: people.existingAssignee.idamId,
+      };
+      let unassignRequestBody: unknown;
+
+      await test.step('Setup case-details task routes and unassign resolvers', async () => {
         await setupTaskActionEndpointMocks(page, 'unassign', {
           taskId: managedTaskId,
           task_name: managedTaskTitle,
@@ -120,7 +184,7 @@ test.describe(
           caseId,
           jurisdiction: 'IA',
           caseTypeId: 'Asylum',
-          assigneeId: people.replacementAssignee.idamId,
+          assigneeId: people.existingAssignee.idamId,
           unassignMode: 'unclaim',
           includeSubmitActionMock: false,
         });
@@ -134,23 +198,6 @@ test.describe(
           taskDueDate,
           state: taskState,
           caseworkers: people.all,
-        });
-
-        await page.route(`**/workallocation/task/${managedTaskId}/assign*`, async (route) => {
-          const request = route.request();
-          if (request.method() !== 'POST') {
-            await route.continue();
-            return;
-          }
-
-          reassignRequestBody = request.postDataJSON();
-          taskState.managedTaskAssigneeId = people.replacementAssignee.idamId;
-
-          await route.fulfill({
-            status: 204,
-            contentType: 'application/json',
-            body: JSON.stringify({}),
-          });
         });
 
         await page.route(`**/workallocation/task/${managedTaskId}/unclaim*`, async (route) => {
@@ -171,44 +218,8 @@ test.describe(
         });
       });
 
-      await test.step('Open the reassign flow from the case-details Tasks tab', async () => {
-        await openCaseDetailsTasksTab(page, caseDetailsPage, caseId);
-
-        await caseDetailsPage.taskItem.filter({ hasText: managedTaskTitle }).first().locator('#action_reassign').click();
-
-        await expect(page).toHaveURL(new RegExp(`/work/${managedTaskId}/reassign\\?service=IA$`));
-        await expect(page.locator('main')).toContainText('Choose a role type');
-        await expect(page.locator('main')).toContainText('Reassign task');
-      });
-
-      await test.step('Complete the reassign flow and verify the refreshed assignee', async () => {
-        await page.getByRole('radio', { name: 'Legal Ops' }).check({ force: true });
-        await taskListPage.continueButton.click();
-
-        await expect(page.locator('main')).toContainText('Find the person');
-        await taskListPage.reassignUserSearchInput.fill('Replacement');
-        await taskListPage.selectFirstReassignUserOption(
-          `${people.replacementAssignee.firstName} ${people.replacementAssignee.lastName}`
-        );
-        await taskListPage.continueButton.click();
-
-        await expect(page.locator('main')).toContainText('Check your answers');
-        await page.getByRole('button', { name: 'Reassign task' }).click();
-
-        expect(reassignRequestBody).toEqual({ userId: people.replacementAssignee.idamId });
-        await expect(caseDetailsPage.caseAlertSuccessMessage).toContainText("You've re-assigned a task.");
-
-        const rows = await caseDetailsPage.getTaskKeyValueRows();
-        const managedTask = getTaskRecordByTitle(rows, managedTaskTitle);
-
-        expect(managedTask).toEqual(
-          expect.objectContaining({
-            'Assigned to': `${people.replacementAssignee.firstName} ${people.replacementAssignee.lastName}`,
-          })
-        );
-      });
-
       await test.step('Open the unassign flow and verify the refreshed unassigned state', async () => {
+        await openCaseDetailsTasksTab(page, caseDetailsPage, caseId);
         await caseDetailsPage.taskItem.filter({ hasText: managedTaskTitle }).first().locator('#action_unclaim').click();
 
         await expect(page).toHaveURL(new RegExp(`/work/${managedTaskId}/unclaim\\?service=IA$`));

--- a/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
@@ -97,17 +97,6 @@ test.describe(
       let unassignRequestBody: unknown;
 
       await test.step('Setup case-details task routes and task-action resolvers', async () => {
-        await setupCaseTaskManageLinksRoutes(page, {
-          caseId,
-          claimTaskId,
-          managedTaskId,
-          claimTaskTitle,
-          managedTaskTitle,
-          taskDueDate,
-          state: taskState,
-          caseworkers: people.all,
-        });
-
         await setupTaskActionEndpointMocks(page, 'reassign', {
           taskId: managedTaskId,
           task_name: managedTaskTitle,
@@ -134,6 +123,17 @@ test.describe(
           assigneeId: people.replacementAssignee.idamId,
           unassignMode: 'unclaim',
           includeSubmitActionMock: false,
+        });
+
+        await setupCaseTaskManageLinksRoutes(page, {
+          caseId,
+          claimTaskId,
+          managedTaskId,
+          claimTaskTitle,
+          managedTaskTitle,
+          taskDueDate,
+          state: taskState,
+          caseworkers: people.all,
         });
 
         await page.route(`**/workallocation/task/${managedTaskId}/assign*`, async (route) => {

--- a/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
@@ -187,7 +187,9 @@ test.describe(
 
         await expect(page.locator('main')).toContainText('Find the person');
         await taskListPage.reassignUserSearchInput.fill('Replacement');
-        await taskListPage.selectFirstReassignUserOption();
+        await taskListPage.selectFirstReassignUserOption(
+          `${people.replacementAssignee.firstName} ${people.replacementAssignee.lastName}`
+        );
         await taskListPage.continueButton.click();
 
         await expect(page.locator('main')).toContainText('Check your answers');

--- a/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts
@@ -87,7 +87,11 @@ test.describe(
       });
     });
 
-    test('opens the reassign flow and loads matching people from the Tasks tab', async ({ caseDetailsPage, taskListPage, page }) => {
+    test('opens the reassign flow and loads matching people from the Tasks tab', async ({
+      caseDetailsPage,
+      taskListPage,
+      page,
+    }) => {
       const currentUserId = await applySessionCookiesAndExtractUserId(page, userIdentifier);
       const people = buildCaseTaskManageLinksCaseworkers(currentUserId);
       const taskState: CaseTaskManageLinksState = {
@@ -163,77 +167,6 @@ test.describe(
           ])
         );
         await expect(taskListPage.reassignUserSearchInput).toHaveValue(/Replacement/i);
-      });
-    });
-
-    test('unassigns a case task from the Tasks tab and refreshes the task card', async ({ caseDetailsPage, page }) => {
-      const currentUserId = await applySessionCookiesAndExtractUserId(page, userIdentifier);
-      const people = buildCaseTaskManageLinksCaseworkers(currentUserId);
-      const taskState: CaseTaskManageLinksState = {
-        managedTaskAssigneeId: people.existingAssignee.idamId,
-      };
-      let unassignRequestBody: unknown;
-
-      await test.step('Setup case-details task routes and unassign resolvers', async () => {
-        await setupTaskActionEndpointMocks(page, 'unassign', {
-          taskId: managedTaskId,
-          task_name: managedTaskTitle,
-          due_date: taskDueDate,
-          dueDate: taskDueDate,
-          priority_date: taskDueDate,
-          caseId,
-          jurisdiction: 'IA',
-          caseTypeId: 'Asylum',
-          assigneeId: people.existingAssignee.idamId,
-          unassignMode: 'unclaim',
-          includeSubmitActionMock: false,
-        });
-
-        await setupCaseTaskManageLinksRoutes(page, {
-          caseId,
-          claimTaskId,
-          managedTaskId,
-          claimTaskTitle,
-          managedTaskTitle,
-          taskDueDate,
-          state: taskState,
-          caseworkers: people.all,
-        });
-
-        await page.route(`**/workallocation/task/${managedTaskId}/unclaim*`, async (route) => {
-          const request = route.request();
-          if (request.method() !== 'POST') {
-            await route.continue();
-            return;
-          }
-
-          unassignRequestBody = request.postDataJSON();
-          taskState.managedTaskAssigneeId = undefined;
-
-          await route.fulfill({
-            status: 204,
-            contentType: 'application/json',
-            body: JSON.stringify({}),
-          });
-        });
-      });
-
-      await test.step('Open the unassign flow and verify the refreshed unassigned state', async () => {
-        await openCaseDetailsTasksTab(page, caseDetailsPage, caseId);
-        await caseDetailsPage.taskItem.filter({ hasText: managedTaskTitle }).first().locator('#action_unclaim').click();
-
-        await expect(page).toHaveURL(new RegExp(`/work/${managedTaskId}/unclaim\\?service=IA$`));
-        await expect(page.locator('main')).toContainText('Unassign task');
-        await page.getByRole('button', { name: 'Unassign task' }).click();
-
-        expect(unassignRequestBody).toEqual({ hasNoAssigneeOnComplete: false });
-        await expect(caseDetailsPage.caseAlertSuccessMessage).toContainText("You've unassigned a task.");
-
-        const rows = await caseDetailsPage.getTaskKeyValueRows();
-        const managedTask = getTaskRecordByTitle(rows, managedTaskTitle);
-
-        expect(managedTask?.['Assigned to']).toBeUndefined();
-        expect(managedTask?.Manage).toContain('Assign to me');
       });
     });
   }

--- a/playwright_tests_new/integration/test/manageTasks/myCases/myCases.manageLinks.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/myCases/myCases.manageLinks.positive.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test } from '../../../../E2E/fixtures';
+import { applySessionCookies, setupMyCasesRoutes } from '../../../helpers';
+import { singleUsersGetByRoleMockResponse } from '../../../helpers/taskActionApiMocks.helper';
+import { buildMyCaseMock, myCasesAllocatorActions } from '../../../mocks/myCases.mock';
+
+const userIdentifier = 'STAFF_ADMIN';
+const replacementUser = singleUsersGetByRoleMockResponse[0];
+
+const managedCases = [
+  buildMyCaseMock({
+    id: 'managed-allocation-1',
+    case_id: '1234567812345670',
+    case_name: 'Managed allocation case 1',
+    case_category: 'Protection',
+    case_type: 'Asylum',
+    jurisdiction: 'IA',
+    jurisdictionId: 'IA',
+    expectedServiceLabel: 'Immigration & Asylum',
+    case_role: 'case-manager',
+    role: 'Case Manager',
+    role_category: 'LEGAL_OPERATIONS',
+    actions: myCasesAllocatorActions,
+  }),
+  buildMyCaseMock({
+    id: 'managed-allocation-2',
+    case_id: '1234567812345671',
+    case_name: 'Managed allocation case 2',
+    case_category: 'Human rights',
+    case_type: 'Asylum',
+    jurisdiction: 'SSCS',
+    jurisdictionId: 'SSCS',
+    expectedServiceLabel: 'Social security and child support',
+    case_role: 'case-manager',
+    role: 'Case Manager',
+    role_category: 'LEGAL_OPERATIONS',
+    actions: myCasesAllocatorActions,
+  }),
+];
+
+const assigneeIdsByAssignmentId: Record<string, string> = {
+  'managed-allocation-1': 'caseworker-existing-1',
+  'managed-allocation-2': 'caseworker-existing-2',
+};
+
+const buildRoleAssignmentResponse = (assignmentId: string) => {
+  const matchingCase = managedCases.find((caseItem) => caseItem.id === assignmentId) ?? managedCases[0];
+
+  return [
+    {
+      id: assignmentId,
+      actorId: assigneeIdsByAssignmentId[assignmentId] ?? 'caseworker-existing-1',
+      name: `Assigned ${matchingCase.case_name}`,
+      email: `${assignmentId}@example.com`,
+      roleCategory: matchingCase.role_category,
+      roleName: matchingCase.role,
+      location: 'Birmingham',
+      start: matchingCase.startDate,
+      end: matchingCase.endDate,
+    },
+  ];
+};
+
+test.beforeEach(async ({ page }) => {
+  await applySessionCookies(page, userIdentifier);
+});
+
+test.describe(`My Cases manage links as ${userIdentifier}`, { tag: ['@integration', '@integration-manage-tasks'] }, () => {
+  test('shows manage actions on each row and completes reallocate and remove-allocation flows', async ({
+    taskListPage,
+    page,
+  }) => {
+    await test.step('Setup My Cases data and role-allocation routes', async () => {
+      await setupMyCasesRoutes(
+        page,
+        {
+          cases: managedCases,
+          total_records: managedCases.length,
+          unique_cases: managedCases.length,
+        },
+        {}
+      );
+
+      await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(singleUsersGetByRoleMockResponse),
+        });
+      });
+
+      await page.route('**/api/role-access/roles/post', async (route) => {
+        const requestBody = (route.request().postDataJSON() as { assignmentId?: string }) ?? {};
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(buildRoleAssignmentResponse(requestBody.assignmentId ?? managedCases[0].id)),
+        });
+      });
+
+      await page.route('**/api/role-access/allocate-role/reallocate', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({}),
+        });
+      });
+
+      await page.route('**/api/role-access/allocate-role/delete', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({}),
+        });
+      });
+    });
+
+    await test.step('Open My Cases and verify manage actions are available for both rows', async () => {
+      await taskListPage.gotoMyCases();
+      await expect(taskListPage.taskListTable).toBeVisible();
+      await taskListPage.exuiSpinnerComponent.wait();
+
+      for (let rowIndex = 0; rowIndex < managedCases.length; rowIndex += 1) {
+        await taskListPage.openManageActionsForRow(rowIndex, `my cases manage menu row ${rowIndex + 1}`);
+        await expect(taskListPage.getTaskActionForRow(rowIndex, 'reallocate')).toBeVisible();
+        await expect(taskListPage.getTaskActionForRow(rowIndex, 'remove')).toBeVisible();
+      }
+    });
+
+    await test.step('Reallocate the first managed case and verify the submitted payload', async () => {
+      const caseItem = managedCases[0];
+
+      await taskListPage.openManageActionsForRow(0, 'my cases reallocate action');
+      await taskListPage.clickTaskActionForRow(0, 'reallocate', 'my cases reallocate action');
+
+      await expect(page).toHaveURL(
+        new RegExp(`/role-access/allocate-role/reallocate\\?caseId=${caseItem.case_id}.*assignmentId=${caseItem.id}`)
+      );
+      await expect(page.locator('main')).toContainText('Find the person');
+
+      await taskListPage.reassignUserSearchInput.fill('test');
+      await taskListPage.selectFirstReassignUserOption();
+      await taskListPage.continueButton.click();
+
+      await expect(page.locator('main')).toContainText('Duration of role');
+      await page.getByLabel('Indefinite').check({ force: true });
+      await taskListPage.continueButton.click();
+
+      await expect(page.locator('main')).toContainText('Check your changes');
+
+      const reallocateRequest = await taskListPage.clickButtonAndWaitForRequest(
+        page.getByRole('button', { name: 'Confirm allocation' }),
+        (request) => request.method() === 'POST' && request.url().includes('/api/role-access/allocate-role/reallocate'),
+        'confirming My Cases role reallocation'
+      );
+
+      expect(reallocateRequest.postDataJSON()).toEqual(
+        expect.objectContaining({
+          action: 'reallocate',
+          caseId: caseItem.case_id,
+          assignmentId: caseItem.id,
+          jurisdiction: caseItem.jurisdictionId,
+          durationOfRole: 'Indefinite',
+          person: expect.objectContaining({
+            id: replacementUser.idamId,
+          }),
+        })
+      );
+
+      await expect(taskListPage.taskListTable).toBeVisible();
+      await expect(taskListPage.exuiBodyComponent.message).toContainText("You've reallocated a role");
+    });
+
+    await test.step('Remove the second managed allocation and verify the submitted payload', async () => {
+      const caseItem = managedCases[1];
+
+      await taskListPage.openManageActionsForRow(1, 'my cases remove allocation action');
+      await taskListPage.clickTaskActionForRow(1, 'remove', 'my cases remove allocation action');
+
+      await expect(page).toHaveURL(
+        new RegExp(`/role-access/allocate-role/remove\\?caseId=${caseItem.case_id}.*assignmentId=${caseItem.id}`)
+      );
+      await expect(page.locator('main')).toContainText('Remove allocation');
+      await expect(page.locator('main')).toContainText(caseItem.role);
+
+      const removeAllocationRequest = await taskListPage.clickButtonAndWaitForRequest(
+        page.getByRole('button', { name: 'Remove allocation' }),
+        (request) => request.method() === 'POST' && request.url().includes('/api/role-access/allocate-role/delete'),
+        'confirming My Cases remove allocation'
+      );
+
+      expect(removeAllocationRequest.postDataJSON()).toEqual({ assigmentId: caseItem.id });
+
+      await expect(taskListPage.taskListTable).toBeVisible();
+      await expect(taskListPage.exuiBodyComponent.message).toContainText(
+        "You've removed a role allocation. You may need to unassign or reassign associated tasks too."
+      );
+    });
+  });
+});

--- a/playwright_tests_new/integration/test/manageTasks/myCases/myCases.manageLinks.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/myCases/myCases.manageLinks.positive.spec.ts
@@ -2,9 +2,14 @@ import { expect, test } from '../../../../E2E/fixtures';
 import { applySessionCookies, setupMyCasesRoutes } from '../../../helpers';
 import { singleUsersGetByRoleMockResponse } from '../../../helpers/taskActionApiMocks.helper';
 import { buildMyCaseMock, myCasesAllocatorActions } from '../../../mocks/myCases.mock';
+import { buildHearingsUserDetailsMock } from '../../../mocks/hearings.mock';
 
 const userIdentifier = 'STAFF_ADMIN';
 const replacementUser = singleUsersGetByRoleMockResponse[0];
+const assigneeIdsByAssignmentId: Record<string, string> = {
+  'managed-allocation-1': 'caseworker-existing-1',
+  'managed-allocation-2': 'caseworker-existing-2',
+};
 
 const managedCases = [
   buildMyCaseMock({
@@ -19,6 +24,7 @@ const managedCases = [
     case_role: 'case-manager',
     role: 'Case Manager',
     role_category: 'LEGAL_OPERATIONS',
+    assignee: assigneeIdsByAssignmentId['managed-allocation-1'],
     actions: myCasesAllocatorActions,
   }),
   buildMyCaseMock({
@@ -33,14 +39,10 @@ const managedCases = [
     case_role: 'case-manager',
     role: 'Case Manager',
     role_category: 'LEGAL_OPERATIONS',
+    assignee: assigneeIdsByAssignmentId['managed-allocation-2'],
     actions: myCasesAllocatorActions,
   }),
 ];
-
-const assigneeIdsByAssignmentId: Record<string, string> = {
-  'managed-allocation-1': 'caseworker-existing-1',
-  'managed-allocation-2': 'caseworker-existing-2',
-};
 
 const buildRoleAssignmentResponse = (assignmentId: string) => {
   const matchingCase = managedCases.find((caseItem) => caseItem.id === assignmentId) ?? managedCases[0];
@@ -77,7 +79,9 @@ test.describe(`My Cases manage links as ${userIdentifier}`, { tag: ['@integratio
           total_records: managedCases.length,
           unique_cases: managedCases.length,
         },
-        {}
+        {
+          userDetails: buildHearingsUserDetailsMock(['caseworker-ia', 'caseworker-ia-caseofficer', 'case-allocator']),
+        }
       );
 
       await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
@@ -139,7 +143,7 @@ test.describe(`My Cases manage links as ${userIdentifier}`, { tag: ['@integratio
       await expect(page.locator('main')).toContainText('Find the person');
 
       await taskListPage.reassignUserSearchInput.fill('test');
-      await taskListPage.selectFirstReassignUserOption();
+      await taskListPage.selectFirstReassignUserOption(`${replacementUser.firstName} ${replacementUser.lastName}`);
       await taskListPage.continueButton.click();
 
       await expect(page.locator('main')).toContainText('Duration of role');

--- a/playwright_tests_new/integration/test/manageTasks/rolesAccess.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/rolesAccess.positive.spec.ts
@@ -1,0 +1,257 @@
+import { RolesAccessPage } from '../../../E2E/page-objects/pages/exui/rolesAccess.po';
+import { expect, test } from '../../../E2E/fixtures';
+import { applySessionCookies } from '../../helpers';
+import { setupRolesAccessMockRoutes } from '../../helpers/rolesAccessMockRoutes.helper';
+import { rolesAccessAllocatorRoleAssignments, rolesAccessNonAllocatorRoleAssignments } from '../../mocks/rolesAccess.mock';
+
+const authenticatedUserIdentifier = 'STAFF_ADMIN';
+const caseId = '1234567812345678';
+
+test.describe('Roles and access parity', { tag: ['@integration', '@integration-manage-tasks'] }, () => {
+  test.beforeEach(async ({ page }) => {
+    await applySessionCookies(page, authenticatedUserIdentifier);
+  });
+
+  test('shows allocator and non-allocator roles-and-access states with the expected actions', async ({ page }) => {
+    const rolesAccessPage = new RolesAccessPage(page);
+
+    await setupRolesAccessMockRoutes(page, {
+      caseId,
+      roleAssignmentInfo: [...rolesAccessAllocatorRoleAssignments],
+      withExistingRoles: false,
+    });
+
+    await test.step('Show the allocator empty states and add links', async () => {
+      await rolesAccessPage.open(caseId);
+
+      await expect(rolesAccessPage.getLink('Allocate a judicial role')).toBeVisible();
+      await expect(rolesAccessPage.getLink('Allocate a legal ops role')).toBeVisible();
+      await expect(rolesAccessPage.getExclusionsAddLink()).toBeVisible();
+
+      await expect(rolesAccessPage.tabPanel).toContainText('There are no judicial roles for this case.');
+      await expect(rolesAccessPage.tabPanel).toContainText('There are no legal Ops roles for this case.');
+      await expect(rolesAccessPage.tabPanel).toContainText('There are no exclusions for this case.');
+    });
+
+    await test.step('Show the populated allocator state with mapped names and no duplicate legal-ops add link', async () => {
+      await setupRolesAccessMockRoutes(page, {
+        caseId,
+        roleAssignmentInfo: [...rolesAccessAllocatorRoleAssignments],
+      });
+      await rolesAccessPage.open(caseId);
+
+      await expect(rolesAccessPage.tabPanel).toContainText('Judge One Full');
+      await expect(rolesAccessPage.tabPanel).toContainText('Alice Example');
+      await expect(rolesAccessPage.tabPanel).toContainText('Judge One Alias');
+      await expect(rolesAccessPage.getLink('Allocate a judicial role')).toBeVisible();
+      await expect(rolesAccessPage.getLink('Allocate a legal ops role')).toHaveCount(0);
+      await expect(rolesAccessPage.getLink('Manage')).toHaveCount(2);
+      await expect(rolesAccessPage.getLink('Delete')).toHaveCount(1);
+    });
+
+    await test.step('Hide manage and allocate links for a non-allocator while leaving the exclusion add link visible', async () => {
+      await setupRolesAccessMockRoutes(page, {
+        caseId,
+        roleAssignmentInfo: [...rolesAccessNonAllocatorRoleAssignments],
+      });
+      await rolesAccessPage.open(caseId);
+
+      await expect(rolesAccessPage.getLink('Manage')).toHaveCount(0);
+      await expect(rolesAccessPage.getLink('Delete')).toHaveCount(0);
+      await expect(rolesAccessPage.getLink('Allocate a judicial role')).toHaveCount(0);
+      await expect(rolesAccessPage.getLink('Allocate a legal ops role')).toHaveCount(0);
+      await expect(rolesAccessPage.getExclusionsAddLink()).toBeVisible();
+    });
+  });
+
+  test('reallocates and removes a judicial role from the Roles and access tab', async ({ page }) => {
+    const rolesAccessPage = new RolesAccessPage(page);
+
+    await setupRolesAccessMockRoutes(page, {
+      caseId,
+      roleAssignmentInfo: [...rolesAccessAllocatorRoleAssignments],
+    });
+
+    await test.step('Open the judicial manage links and reallocate the role', async () => {
+      await rolesAccessPage.open(caseId);
+
+      await rolesAccessPage.getLink('Manage').first().click();
+      await expect(rolesAccessPage.getLink('Reallocate').first()).toBeVisible();
+      await expect(rolesAccessPage.getLink('Remove Allocation').first()).toBeVisible();
+
+      await rolesAccessPage.getLink('Reallocate').first().click();
+      await expect(page.locator('main')).toContainText('Find the person');
+
+      await rolesAccessPage.searchAndSelectPerson('Replacement', 'Replacement Judge');
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(page.locator('main')).toContainText('Duration of role');
+      await page.getByLabel('Indefinite').check({ force: true });
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(page.locator('main')).toContainText('Check your changes');
+      await expect(page.locator('.govuk-summary-list')).toContainText('Replacement Judge');
+
+      const reallocateRequestPromise = page.waitForRequest(
+        (request) => request.method() === 'POST' && request.url().includes('/api/role-access/allocate-role/reallocate')
+      );
+
+      await page.getByRole('button', { name: 'Confirm allocation' }).click();
+
+      const reallocateRequest = await reallocateRequestPromise;
+      expect(reallocateRequest.postDataJSON()).toEqual(
+        expect.objectContaining({
+          action: 'reallocate',
+          assignmentId: 'judicial-role-1',
+          caseId,
+          durationOfRole: 'Indefinite',
+          jurisdiction: 'IA',
+          person: expect.objectContaining({
+            id: 'judicial-replacement-1',
+          }),
+        })
+      );
+
+      await expect(page).toHaveURL(new RegExp(`/cases/case-details/IA/Asylum/${caseId}(?:#.*)?$`));
+      await rolesAccessPage.open(caseId);
+      await expect(rolesAccessPage.tabPanel).toContainText('Replacement Judge');
+    });
+
+    await test.step('Remove the reallocated judicial role and verify the submitted payload', async () => {
+      await rolesAccessPage.getLink('Manage').first().click();
+      await rolesAccessPage.getLink('Remove Allocation').first().click();
+
+      await expect(page.locator('main')).toContainText('Remove allocation');
+
+      const removeRequestPromise = page.waitForRequest(
+        (request) => request.method() === 'POST' && request.url().includes('/api/role-access/allocate-role/delete')
+      );
+
+      await page.getByRole('button', { name: 'Remove allocation' }).click();
+
+      const removeRequest = await removeRequestPromise;
+      expect(removeRequest.postDataJSON()).toEqual({ assigmentId: 'judicial-role-1' });
+
+      await expect(page).toHaveURL(new RegExp(`/cases/case-details/IA/Asylum/${caseId}(?:#.*)?$`));
+      await rolesAccessPage.open(caseId);
+      await expect(rolesAccessPage.tabPanel).toContainText('There are no judicial roles for this case.');
+      await expect(rolesAccessPage.tabPanel).toContainText('Alice Example');
+    });
+  });
+
+  test('supports exclusion change links and confirms the updated exclusion payload', async ({ page }) => {
+    const rolesAccessPage = new RolesAccessPage(page);
+
+    await setupRolesAccessMockRoutes(page, {
+      caseId,
+      roleAssignmentInfo: [...rolesAccessAllocatorRoleAssignments],
+    });
+
+    await test.step('Open the add-exclusion workflow and reach check answers', async () => {
+      await rolesAccessPage.open(caseId);
+
+      await rolesAccessPage.getExclusionsAddLink().click();
+      await expect(page.locator('main')).toContainText('Choose who the exclusion is for');
+      await page.getByRole('radio', { name: 'Exclude another person' }).check({ force: true });
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(page.locator('main')).toContainText("Choose the person's role");
+      await page.getByRole('radio', { name: 'Judicial' }).check({ force: true });
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(page.locator('main')).toContainText('Find the person');
+      await rolesAccessPage.searchAndSelectPerson('Replacement', 'Replacement Judge');
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(page.locator('main')).toContainText('Describe the exclusion');
+      await page.locator('#exclusion-description').fill('Initial judicial exclusion');
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(page.locator('main')).toContainText('Check your answers');
+      await expect(rolesAccessPage.getSummaryRow('Who is the exclusion for')).toContainText('Exclude another person');
+      await expect(rolesAccessPage.getSummaryRow("What's the person's role")).toContainText('Judicial');
+      await expect(rolesAccessPage.getSummaryRow('Person')).toContainText('Replacement Judge');
+      await expect(rolesAccessPage.getSummaryRow('Describe the exclusion')).toContainText('Initial judicial exclusion');
+    });
+
+    await test.step('Exercise each change link and confirm the updated answers', async () => {
+      await rolesAccessPage
+        .getSummaryRow('Who is the exclusion for')
+        .getByRole('button', { name: /change/i })
+        .click();
+      await expect(page.locator('main')).toContainText('Choose who the exclusion is for');
+      await page.getByRole('radio', { name: 'Exclude another person' }).check({ force: true });
+      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(page.locator('main')).toContainText("Choose the person's role");
+      await page.getByRole('radio', { name: 'Judicial' }).check({ force: true });
+      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(page.locator('main')).toContainText('Find the person');
+      await rolesAccessPage.searchAndSelectPerson('Alternate', 'Alternate Judge');
+      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(page.locator('main')).toContainText('Describe the exclusion');
+      await page.locator('#exclusion-description').fill('Initial judicial exclusion');
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await rolesAccessPage
+        .getSummaryRow("What's the person's role")
+        .getByRole('button', { name: /change/i })
+        .click();
+      await expect(page.locator('main')).toContainText("Choose the person's role");
+      await page.getByRole('radio', { name: 'Judicial' }).check({ force: true });
+      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(page.locator('main')).toContainText('Find the person');
+      await rolesAccessPage.searchAndSelectPerson('Replacement', 'Replacement Judge');
+      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(page.locator('main')).toContainText('Describe the exclusion');
+      await page.locator('#exclusion-description').fill('Initial judicial exclusion');
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await rolesAccessPage
+        .getSummaryRow('Person')
+        .getByRole('button', { name: /change/i })
+        .click();
+      await expect(page.locator('main')).toContainText('Find the person');
+      await rolesAccessPage.searchAndSelectPerson('Alternate', 'Alternate Judge');
+      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(page.locator('main')).toContainText('Describe the exclusion');
+      await page.locator('#exclusion-description').fill('Initial judicial exclusion');
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await rolesAccessPage
+        .getSummaryRow('Describe the exclusion')
+        .getByRole('button', { name: /change/i })
+        .click();
+      await expect(page.locator('main')).toContainText('Describe the exclusion');
+      await page.locator('#exclusion-description').fill('Updated judicial exclusion');
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(rolesAccessPage.getSummaryRow('Person')).toContainText('Alternate Judge');
+      await expect(rolesAccessPage.getSummaryRow('Describe the exclusion')).toContainText('Updated judicial exclusion');
+    });
+
+    await test.step('Confirm the exclusion and verify the payload', async () => {
+      const confirmExclusionRequestPromise = page.waitForRequest(
+        (request) => request.method() === 'POST' && request.url().includes('/api/role-access/exclusions/confirm')
+      );
+
+      await page.getByRole('button', { name: 'Confirm exclusion' }).click();
+
+      const confirmExclusionRequest = await confirmExclusionRequestPromise;
+      expect(confirmExclusionRequest.postDataJSON()).toEqual(
+        expect.objectContaining({
+          caseId,
+          caseType: 'Asylum',
+          exclusionDescription: 'Updated judicial exclusion',
+          jurisdiction: 'IA',
+          person: expect.objectContaining({
+            id: 'judicial-replacement-2',
+          }),
+        })
+      );
+
+      await expect(page).toHaveURL(new RegExp(`/cases/case-details/IA/Asylum/${caseId}/roles-and-access(?:\\?.*)?$`));
+      await expect(rolesAccessPage.tabPanel).toContainText('Alternate Judge');
+      await expect(rolesAccessPage.tabPanel).toContainText('Updated judicial exclusion');
+    });
+  });
+});

--- a/playwright_tests_new/integration/test/manageTasks/rolesAccess.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/rolesAccess.positive.spec.ts
@@ -24,8 +24,8 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
     await test.step('Show the allocator empty states and add links', async () => {
       await rolesAccessPage.open(caseId);
 
-      await expect(rolesAccessPage.getLink('Allocate a judicial role')).toBeVisible();
-      await expect(rolesAccessPage.getLink('Allocate a legal ops role')).toBeVisible();
+      await expect(rolesAccessPage.getAllocateJudicialRoleLink()).toBeVisible();
+      await expect(rolesAccessPage.getAllocateLegalOpsRoleLink()).toBeVisible();
       await expect(rolesAccessPage.getExclusionsAddLink()).toBeVisible();
 
       await expect(rolesAccessPage.tabPanel).toContainText('There are no judicial roles for this case.');
@@ -43,10 +43,10 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
       await expect(rolesAccessPage.tabPanel).toContainText('Judge One Full');
       await expect(rolesAccessPage.tabPanel).toContainText('Alice Example');
       await expect(rolesAccessPage.tabPanel).toContainText('Judge One Alias');
-      await expect(rolesAccessPage.getLink('Allocate a judicial role')).toBeVisible();
-      await expect(rolesAccessPage.getLink('Allocate a legal ops role')).toHaveCount(0);
-      await expect(rolesAccessPage.getLink('Manage')).toHaveCount(2);
-      await expect(rolesAccessPage.getLink('Delete')).toHaveCount(1);
+      await expect(rolesAccessPage.getAllocateJudicialRoleLink()).toBeVisible();
+      await expect(rolesAccessPage.getAllocateLegalOpsRoleLink()).toHaveCount(0);
+      await expect(rolesAccessPage.getManageLinks()).toHaveCount(2);
+      await expect(rolesAccessPage.getDeleteLinks()).toHaveCount(1);
     });
 
     await test.step('Hide manage and allocate links for a non-allocator while leaving the exclusion add link visible', async () => {
@@ -56,10 +56,10 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
       });
       await rolesAccessPage.open(caseId);
 
-      await expect(rolesAccessPage.getLink('Manage')).toHaveCount(0);
-      await expect(rolesAccessPage.getLink('Delete')).toHaveCount(0);
-      await expect(rolesAccessPage.getLink('Allocate a judicial role')).toHaveCount(0);
-      await expect(rolesAccessPage.getLink('Allocate a legal ops role')).toHaveCount(0);
+      await expect(rolesAccessPage.getManageLinks()).toHaveCount(0);
+      await expect(rolesAccessPage.getDeleteLinks()).toHaveCount(0);
+      await expect(rolesAccessPage.getAllocateJudicialRoleLink()).toHaveCount(0);
+      await expect(rolesAccessPage.getAllocateLegalOpsRoleLink()).toHaveCount(0);
       await expect(rolesAccessPage.getExclusionsAddLink()).toBeVisible();
     });
   });
@@ -75,28 +75,28 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
     await test.step('Open the judicial manage links and reallocate the role', async () => {
       await rolesAccessPage.open(caseId);
 
-      await rolesAccessPage.getLink('Manage').first().click();
-      await expect(rolesAccessPage.getLink('Reallocate').first()).toBeVisible();
-      await expect(rolesAccessPage.getLink('Remove Allocation').first()).toBeVisible();
+      await rolesAccessPage.openFirstManageLink();
+      await expect(rolesAccessPage.getReallocateLinks().first()).toBeVisible();
+      await expect(rolesAccessPage.getRemoveAllocationLinks().first()).toBeVisible();
 
-      await rolesAccessPage.getLink('Reallocate').first().click();
-      await expect(page.locator('main')).toContainText('Find the person');
+      await rolesAccessPage.openFirstReallocateLink();
+      await expect(rolesAccessPage.mainContent).toContainText('Find the person');
 
       await rolesAccessPage.searchAndSelectPerson('Replacement', 'Replacement Judge');
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await rolesAccessPage.continue();
 
-      await expect(page.locator('main')).toContainText('Duration of role');
-      await page.getByLabel('Indefinite').check({ force: true });
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(rolesAccessPage.mainContent).toContainText('Duration of role');
+      await rolesAccessPage.selectIndefiniteDuration();
+      await rolesAccessPage.continue();
 
-      await expect(page.locator('main')).toContainText('Check your changes');
+      await expect(rolesAccessPage.mainContent).toContainText('Check your changes');
       await expect(page.locator('.govuk-summary-list')).toContainText('Replacement Judge');
 
       const reallocateRequestPromise = page.waitForRequest(
         (request) => request.method() === 'POST' && request.url().includes('/api/role-access/allocate-role/reallocate')
       );
 
-      await page.getByRole('button', { name: 'Confirm allocation' }).click();
+      await rolesAccessPage.confirmAllocation();
 
       const reallocateRequest = await reallocateRequestPromise;
       expect(reallocateRequest.postDataJSON()).toEqual(
@@ -118,16 +118,16 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
     });
 
     await test.step('Remove the reallocated judicial role and verify the submitted payload', async () => {
-      await rolesAccessPage.getLink('Manage').first().click();
-      await rolesAccessPage.getLink('Remove Allocation').first().click();
+      await rolesAccessPage.openFirstManageLink();
+      await rolesAccessPage.openFirstRemoveAllocationLink();
 
-      await expect(page.locator('main')).toContainText('Remove allocation');
+      await expect(rolesAccessPage.mainContent).toContainText('Remove allocation');
 
       const removeRequestPromise = page.waitForRequest(
         (request) => request.method() === 'POST' && request.url().includes('/api/role-access/allocate-role/delete')
       );
 
-      await page.getByRole('button', { name: 'Remove allocation' }).click();
+      await rolesAccessPage.removeAllocation();
 
       const removeRequest = await removeRequestPromise;
       expect(removeRequest.postDataJSON()).toEqual({ assigmentId: 'judicial-role-1' });
@@ -151,23 +151,23 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
       await rolesAccessPage.open(caseId);
 
       await rolesAccessPage.getExclusionsAddLink().click();
-      await expect(page.locator('main')).toContainText('Choose who the exclusion is for');
-      await page.getByRole('radio', { name: 'Exclude another person' }).check({ force: true });
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(rolesAccessPage.mainContent).toContainText('Choose who the exclusion is for');
+      await rolesAccessPage.chooseExclusionForAnotherPerson();
+      await rolesAccessPage.continue();
 
-      await expect(page.locator('main')).toContainText("Choose the person's role");
-      await page.getByRole('radio', { name: 'Judicial' }).check({ force: true });
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(rolesAccessPage.mainContent).toContainText("Choose the person's role");
+      await rolesAccessPage.chooseJudicialPersonRole();
+      await rolesAccessPage.continue();
 
-      await expect(page.locator('main')).toContainText('Find the person');
+      await expect(rolesAccessPage.mainContent).toContainText('Find the person');
       await rolesAccessPage.searchAndSelectPerson('Replacement', 'Replacement Judge');
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await rolesAccessPage.continue();
 
-      await expect(page.locator('main')).toContainText('Describe the exclusion');
-      await page.locator('#exclusion-description').fill('Initial judicial exclusion');
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(rolesAccessPage.mainContent).toContainText('Describe the exclusion');
+      await rolesAccessPage.fillExclusionDescription('Initial judicial exclusion');
+      await rolesAccessPage.continue();
 
-      await expect(page.locator('main')).toContainText('Check your answers');
+      await expect(rolesAccessPage.mainContent).toContainText('Check your answers');
       await expect(rolesAccessPage.getSummaryRow('Who is the exclusion for')).toContainText('Exclude another person');
       await expect(rolesAccessPage.getSummaryRow("What's the person's role")).toContainText('Judicial');
       await expect(rolesAccessPage.getSummaryRow('Person')).toContainText('Replacement Judge');
@@ -175,55 +175,43 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
     });
 
     await test.step('Exercise each change link and confirm the updated answers', async () => {
-      await rolesAccessPage
-        .getSummaryRow('Who is the exclusion for')
-        .getByRole('button', { name: /change/i })
-        .click();
-      await expect(page.locator('main')).toContainText('Choose who the exclusion is for');
-      await page.getByRole('radio', { name: 'Exclude another person' }).check({ force: true });
-      await page.getByRole('button', { name: 'Continue' }).click();
-      await expect(page.locator('main')).toContainText("Choose the person's role");
-      await page.getByRole('radio', { name: 'Judicial' }).check({ force: true });
-      await page.getByRole('button', { name: 'Continue' }).click();
-      await expect(page.locator('main')).toContainText('Find the person');
+      await rolesAccessPage.getSummaryChangeButton('Who is the exclusion for').click();
+      await expect(rolesAccessPage.mainContent).toContainText('Choose who the exclusion is for');
+      await rolesAccessPage.chooseExclusionForAnotherPerson();
+      await rolesAccessPage.continue();
+      await expect(rolesAccessPage.mainContent).toContainText("Choose the person's role");
+      await rolesAccessPage.chooseJudicialPersonRole();
+      await rolesAccessPage.continue();
+      await expect(rolesAccessPage.mainContent).toContainText('Find the person');
       await rolesAccessPage.searchAndSelectPerson('Alternate', 'Alternate Judge');
-      await page.getByRole('button', { name: 'Continue' }).click();
-      await expect(page.locator('main')).toContainText('Describe the exclusion');
-      await page.locator('#exclusion-description').fill('Initial judicial exclusion');
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await rolesAccessPage.continue();
+      await expect(rolesAccessPage.mainContent).toContainText('Describe the exclusion');
+      await rolesAccessPage.fillExclusionDescription('Initial judicial exclusion');
+      await rolesAccessPage.continue();
 
-      await rolesAccessPage
-        .getSummaryRow("What's the person's role")
-        .getByRole('button', { name: /change/i })
-        .click();
-      await expect(page.locator('main')).toContainText("Choose the person's role");
-      await page.getByRole('radio', { name: 'Judicial' }).check({ force: true });
-      await page.getByRole('button', { name: 'Continue' }).click();
-      await expect(page.locator('main')).toContainText('Find the person');
+      await rolesAccessPage.getSummaryChangeButton("What's the person's role").click();
+      await expect(rolesAccessPage.mainContent).toContainText("Choose the person's role");
+      await rolesAccessPage.chooseJudicialPersonRole();
+      await rolesAccessPage.continue();
+      await expect(rolesAccessPage.mainContent).toContainText('Find the person');
       await rolesAccessPage.searchAndSelectPerson('Replacement', 'Replacement Judge');
-      await page.getByRole('button', { name: 'Continue' }).click();
-      await expect(page.locator('main')).toContainText('Describe the exclusion');
-      await page.locator('#exclusion-description').fill('Initial judicial exclusion');
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await rolesAccessPage.continue();
+      await expect(rolesAccessPage.mainContent).toContainText('Describe the exclusion');
+      await rolesAccessPage.fillExclusionDescription('Initial judicial exclusion');
+      await rolesAccessPage.continue();
 
-      await rolesAccessPage
-        .getSummaryRow('Person')
-        .getByRole('button', { name: /change/i })
-        .click();
-      await expect(page.locator('main')).toContainText('Find the person');
+      await rolesAccessPage.getSummaryChangeButton('Person').click();
+      await expect(rolesAccessPage.mainContent).toContainText('Find the person');
       await rolesAccessPage.searchAndSelectPerson('Alternate', 'Alternate Judge');
-      await page.getByRole('button', { name: 'Continue' }).click();
-      await expect(page.locator('main')).toContainText('Describe the exclusion');
-      await page.locator('#exclusion-description').fill('Initial judicial exclusion');
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await rolesAccessPage.continue();
+      await expect(rolesAccessPage.mainContent).toContainText('Describe the exclusion');
+      await rolesAccessPage.fillExclusionDescription('Initial judicial exclusion');
+      await rolesAccessPage.continue();
 
-      await rolesAccessPage
-        .getSummaryRow('Describe the exclusion')
-        .getByRole('button', { name: /change/i })
-        .click();
-      await expect(page.locator('main')).toContainText('Describe the exclusion');
-      await page.locator('#exclusion-description').fill('Updated judicial exclusion');
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await rolesAccessPage.getSummaryChangeButton('Describe the exclusion').click();
+      await expect(rolesAccessPage.mainContent).toContainText('Describe the exclusion');
+      await rolesAccessPage.fillExclusionDescription('Updated judicial exclusion');
+      await rolesAccessPage.continue();
 
       await expect(rolesAccessPage.getSummaryRow('Person')).toContainText('Alternate Judge');
       await expect(rolesAccessPage.getSummaryRow('Describe the exclusion')).toContainText('Updated judicial exclusion');
@@ -234,7 +222,7 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
         (request) => request.method() === 'POST' && request.url().includes('/api/role-access/exclusions/confirm')
       );
 
-      await page.getByRole('button', { name: 'Confirm exclusion' }).click();
+      await rolesAccessPage.confirmExclusion();
 
       const confirmExclusionRequest = await confirmExclusionRequestPromise;
       expect(confirmExclusionRequest.postDataJSON()).toEqual(
@@ -249,7 +237,9 @@ test.describe('Roles and access parity', { tag: ['@integration', '@integration-m
         })
       );
 
-      await expect(page).toHaveURL(new RegExp(`/cases/case-details/IA/Asylum/${caseId}/roles-and-access(?:\\?.*)?$`));
+      await expect(page).toHaveURL(
+        new RegExp(`/cases/case-details/IA/Asylum/${caseId}(?:/roles-and-access(?:\\?.*)?|#Roles%20and%20access)$`)
+      );
       await expect(rolesAccessPage.tabPanel).toContainText('Alternate Judge');
       await expect(rolesAccessPage.tabPanel).toContainText('Updated judicial exclusion');
     });


### PR DESCRIPTION
### Jira link

See [EXUI-4512](https://tools.hmcts.net/jira/browse/EXUI-4512)

### Change description

This PR delivers the second narrow `EXUI-4512` slice: manage-links and roles coverage rebuilt cleanly on top of current `master`, without carrying the oversized mixed scope from `#5091`.

What changed:
- adds focused Playwright integration coverage for `My Cases` manage links
- adds focused Playwright integration coverage for case-details `Tasks` tab claim and reassign journeys
- adds focused Playwright integration coverage for `Roles and access` allocator gating, judicial role reallocation and removal, and exclusion change-link journeys
- adds direct `node-api` coverage for the extracted mock builders that own this support logic
- extracts Roles and access interaction plumbing into a dedicated page object instead of leaving heavy setup and selectors inside the spec
- keeps the `taskManageLinks` slice trimmed to the stable value-bearing flows after removing the unstable case-details unassign path from this PR

Value added to the test pack:
- protects the real allocator-driven actions that users take after lists are already loaded, which was still under-covered after the earlier `4512A` list, pagination, and filter slice
- proves that `My Cases` manage menus do not just render, but submit the correct `reallocate` and `remove allocation` payloads for allocator-backed rows
- proves that case-details task actions from the `Tasks` tab can successfully drive the claim journey and the reassign entry journey, with the expected task-card refresh and user-search load behaviour
- proves that `Roles and access` is correctly gated by allocator entitlements, so non-allocators do not see allocator-only actions while allocators do
- proves that judicial role management is wired through the expected request contracts, including `reallocate`, `delete`, and exclusion confirmation payloads
- adds direct unit-level protection around the extracted mock builders, so shared support regressions fail fast before they are buried inside browser flows
- keeps this PR reviewable and safer to merge by isolating just the manage-links and roles value, instead of bundling it with unrelated platform-services, CCD toolkit, or risky app-side changes

Why this split matters:
- `4512A` already covered list, pagination, and filter behaviour
- this PR covers the next behavioural layer: what users can do from those lists and from `Roles and access` once allocator-driven actions are available
- keeping this as a separate PR makes the behavioural intent obvious and limits the change surface to a small reviewable slice

### Dependency PRs

- None

### Testing done

Executed locally:
- `git diff --check`
- `./node_modules/.bin/prettier --check` on the touched files
- `./node_modules/.bin/eslint` on the touched files
- `PLAYWRIGHT_SKIP_INSTALL=true yarn playwright test --project=node-api playwright_tests_new/api/unit/case-task-manage-links.mock.unit.api.ts playwright_tests_new/api/unit/roles-access.mock.unit.api.ts`
- `PLAYWRIGHT_SKIP_INSTALL=true ./node_modules/.bin/playwright test --config=playwright.integration.config.ts playwright_tests_new/integration/test/manageTasks/caseTaskList/taskManageLinks.positive.spec.ts playwright_tests_new/integration/test/manageTasks/myCases/myCases.manageLinks.positive.spec.ts playwright_tests_new/integration/test/manageTasks/rolesAccess.positive.spec.ts --workers 1 --retries 0`
- `PATH="./node_modules/.bin:$PATH" yarn lint`

Results:
- node-api: `5 passed`
- Playwright integration execution: `6 passed`
- lint: passed with the repo existing warning baseline only, `0` errors

Environment note:
- earlier review rounds were limited by environment availability, but the current branch now has successful focused local browser execution evidence for the retained three-spec slice
- broader environment-dependent validation may still need rerunning in CI as normal, but this PR is no longer relying on `--list`-only evidence

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [ ] Can this PR be released on a Friday (ie: no functional code changes)
