### PR TITLE
EXUI-4534: add shared manage-tasks Playwright foundation

### DIFF
--- a/playwright_tests_new/E2E/page-objects/pages/exui/taskList.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/taskList.po.ts
@@ -2,6 +2,8 @@ import { expect, Locator, Page, Request } from '@playwright/test';
 import { Base } from '../../base';
 
 const TASK_LIST_READY_TIMEOUT_MS = 30_000;
+const TASK_LIST_BOOTSTRAP_RETRY_TIMEOUT_MS = 12_000;
+const TASK_LIST_NAVIGATION_ATTEMPTS = 2;
 const FILTER_PANEL_READY_TIMEOUT_MS = 10_000;
 const FILTER_CONTROL_READY_TIMEOUT_MS = 15_000;
 const FILTER_GROUP_OPERATION_TIMEOUT_MS = 10_000;
@@ -9,10 +11,14 @@ const FILTER_INTERACTION_ATTEMPTS = 2;
 const PRIORITY_LIMIT_URGENT = 2000;
 const PRIORITY_LIMIT_HIGH = 5000;
 
+const escapeForRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 export class TaskListPage extends Base {
   readonly myWorkHeading = this.page.getByRole('heading', { name: /my work/i }).first();
-  readonly taskListFilterToggle = this.page.locator('exui-task-list-filter .govuk-button.hmcts-button--secondary').first();
-  readonly filterPanel = this.page.locator('xuilib-generic-filter');
+  readonly taskListFilterToggle = this.page
+    .locator('exui-task-list-filter .govuk-button.hmcts-button--secondary:visible')
+    .first();
+  readonly filterPanel = this.page.locator('xuilib-generic-filter:visible').first();
   readonly selectAllServicesFilter = this.filterPanel.locator('input#checkbox_servicesservices_all').first();
   readonly serviceFilterCheckboxes = this.filterPanel.locator(
     '#services .govuk-checkboxes__input:not(#checkbox_servicesservices_all)'
@@ -25,10 +31,13 @@ export class TaskListPage extends Base {
   );
 
   readonly selectTypesOfWorksError = this.filterPanel.locator('#types-of-work-error').first();
-  readonly applyFilterButton = this.page.locator('button#applyFilter').first();
+  readonly applyFilterButton = this.filterPanel.locator('button#applyFilter').first();
 
   readonly allWorkServiceFilter = this.filterPanel
-    .locator('select[name="service"], select#service, [id*="service"] select')
+    .locator('select#select_service, select[name="select_service"], select#service, select[name="service"]')
+    .first();
+  readonly allWorkCasesServiceFilter = this.filterPanel
+    .locator('select#select_jurisdiction, select[name="select_jurisdiction"]')
     .first();
   readonly allWorkLocationAllRadio = this.filterPanel.getByRole('radio', { name: /^All$/ }).first();
   readonly allWorkLocationSearchRadio = this.filterPanel.getByRole('radio', { name: 'Search for a location' }).first();
@@ -37,17 +46,24 @@ export class TaskListPage extends Base {
   readonly allWorkTaskCategoryAssignedToPersonRadio = this.filterPanel
     .getByRole('radio', { name: 'Assigned to a person' })
     .first();
+  readonly allWorkCasesRoleTypeFilter = this.filterPanel.locator('select#select_role, select[name="select_role"]').first();
   readonly allWorkTaskTypeFilter = this.filterPanel.getByRole('combobox', { name: /select a role type|task type/i }).first();
   readonly allWorkTasksByRoleTypeFilter = this.filterPanel
     .locator('h3:has-text("Tasks by role type")')
     .locator('xpath=following::select[1]')
     .first();
   readonly allWorkPersonSearchInput = this.filterPanel.getByRole('combobox', { name: /select a person/i }).first();
-  readonly allWorkLocationSearchInput = this.filterPanel.locator('#locations exui-search-location input').first();
+  readonly locationFilterSection = this.filterPanel.locator('#locations').first();
+  readonly locationPicker = this.filterPanel
+    .locator('xuilib-find-location')
+    .filter({ has: this.page.locator('input#inputLocationSearch:visible') })
+    .first();
+  readonly allWorkLocationSearchInput = this.locationPicker.locator('input#inputLocationSearch').first();
+  readonly allWorkAutocompleteOptions = this.page.locator('.cdk-overlay-container .mat-autocomplete-panel [role="option"]');
   readonly allWorkLocationSearchResults = this.page.locator('.cdk-overlay-container .mat-autocomplete-panel mat-option span');
-  readonly selectedLocationTags = this.filterPanel.locator(
-    '#locations xuilib-find-location .location-picker-custom .location-selection a'
-  );
+  readonly selectedLocationTags = this.locationPicker.locator('.location-picker-custom .location-selection a.hmcts-filter__tag');
+  readonly allWorkCasesApplyPrompt = this.page.getByText('Please select filters and click Apply').first();
+  readonly allWorkCasesEmptyMessage = this.page.getByText('Change your selection to view cases').first();
 
   readonly taskTableTabs = this.page.locator('.hmcts-sub-navigation .hmcts-sub-navigation__link');
 
@@ -62,7 +78,7 @@ export class TaskListPage extends Base {
   readonly taskTableHeader = this.taskListTable.locator('thead');
   readonly taskTableFooter = this.taskListTable.locator('tfoot');
   readonly taskListResultsAmount = this.page.locator('#search-result-summary__text, [data-test="search-result-summary__text"]');
-  readonly myCasesResultsAmount = this.page.locator('.pagination-top');
+  readonly myCasesResultsAmount = this.page.locator('.pagination-top').first();
   readonly uniqueCasesSummary = this.page.locator('.second-line');
   readonly myAccessNewCasesBadge = this.page.locator('.xui-alert-link__number');
   readonly manageCaseButtons = this.taskListTable.getByRole('button', { name: 'Manage' });
@@ -90,7 +106,9 @@ export class TaskListPage extends Base {
   readonly cancelledTaskMessage = this.page.getByText("You've cancelled a task. It has been removed from the task list.");
   readonly taskNoLongerAvailableMessage = this.page.getByText('The task is no longer available.');
 
-  readonly paginationControls = this.page.locator('.ngx-pagination');
+  readonly paginationControls = this.page
+    .locator('.ngx-pagination, nav[aria-label="Pagination"], [role="navigation"][aria-label="Pagination"]')
+    .first();
   readonly paginationNextButton = this.paginationControls.locator('.pagination-next');
   readonly paginationEllipsisButton = this.paginationControls.locator('.ellipsis');
   readonly paginationPreviousButton = this.paginationControls.locator('.pagination-previous');
@@ -100,8 +118,10 @@ export class TaskListPage extends Base {
   readonly continueButton = this.page.locator('.govuk-button').filter({ hasText: 'Continue' });
 
   readonly reassignUserSearchInput = this.page.locator('#inputSelectPerson');
-  readonly reassignUserAutocompleteOverlay = this.page.locator('.cdk-overlay-pane');
-  readonly reassignUserAutocompleteFirstOption = this.page.getByRole('option').first();
+  readonly autocompleteOverlay = this.page.locator('.cdk-overlay-pane').filter({
+    has: this.page.locator('[role="option"]'),
+  });
+  readonly autocompleteFirstOption = this.autocompleteOverlay.locator('[role="option"]').first();
   readonly reassignButton = this.page.getByRole('button', { name: 'Reassign' });
 
   constructor(page: Page) {
@@ -149,6 +169,10 @@ export class TaskListPage extends Base {
     await this.navigateToTaskListView('/work/all-work/tasks', /\/work\/all-work\/tasks(?:\?.*)?$/, 'all work tasks navigation');
   }
 
+  async gotoAllWorkCases() {
+    await this.navigateToTaskListView('/work/all-work/cases', /\/work\/all-work\/cases(?:\?.*)?$/, 'all work cases navigation');
+  }
+
   async selectWorkMenuItem(menuItemText: string) {
     const menuItem = this.page.getByRole('link', { name: menuItemText, exact: true });
     await menuItem.click();
@@ -156,6 +180,11 @@ export class TaskListPage extends Base {
 
   async getResultsText() {
     return await this.taskListResultsAmount.textContent();
+  }
+
+  async getPaginationSummaryText() {
+    const summaryText = (await this.myCasesResultsAmount.textContent()) ?? '';
+    return summaryText.replace(/\s+/g, ' ').trim();
   }
 
   getExpectedPriorityLabel(majorPriority?: number | string, priorityDate?: string | Date, currentDate: Date = new Date()) {
@@ -226,11 +255,31 @@ export class TaskListPage extends Base {
     context: string,
     timeoutMs = TASK_LIST_READY_TIMEOUT_MS
   ) {
-    await this.page.goto(path, { waitUntil: 'domcontentloaded' });
-    await this.page.waitForURL(urlPattern, { timeout: timeoutMs }).catch(() => undefined);
-    await this.waitForExuiAppShell(context, timeoutMs);
-    await this.waitForTaskListSpinnerToSettle(10_000);
-    await this.waitForTaskListShellReady(context);
+    let lastError: Error | undefined;
+
+    for (let attempt = 1; attempt <= TASK_LIST_NAVIGATION_ATTEMPTS; attempt += 1) {
+      await this.page.goto(path, { waitUntil: 'domcontentloaded' });
+      await this.page.waitForURL(urlPattern, { timeout: timeoutMs }).catch(() => undefined);
+
+      try {
+        await this.waitForExuiAppShell(context, timeoutMs);
+        await this.waitForTaskListSpinnerToSettle(10_000);
+        await this.waitForTaskListShellReady(
+          `${context}${attempt > 1 ? ` retry ${attempt}` : ''}`,
+          attempt === TASK_LIST_NAVIGATION_ATTEMPTS ? timeoutMs : TASK_LIST_BOOTSTRAP_RETRY_TIMEOUT_MS
+        );
+        return;
+      } catch (error) {
+        lastError = error as Error;
+        if (attempt === TASK_LIST_NAVIGATION_ATTEMPTS || this.page.isClosed()) {
+          throw lastError;
+        }
+      }
+    }
+
+    if (lastError) {
+      throw lastError;
+    }
   }
 
   private async waitForExuiAppShell(context: string, timeoutMs: number): Promise<void> {
@@ -257,7 +306,7 @@ export class TaskListPage extends Base {
     }
   }
 
-  async waitForTaskListShellReady(context: string) {
+  async waitForTaskListShellReady(context: string, timeoutMs = TASK_LIST_READY_TIMEOUT_MS) {
     const findVisibleShellSignal = async () => {
       const signals: Array<[string, Locator]> = [
         ['heading', this.myWorkHeading],
@@ -282,7 +331,7 @@ export class TaskListPage extends Base {
 
     await this.page
       .waitForURL(/\/(?:work\/(?:my-work\/(?:list|available|my-cases|my-access)|all-work\/(?:tasks|cases))|service-down)/, {
-        timeout: TASK_LIST_READY_TIMEOUT_MS,
+        timeout: timeoutMs,
       })
       .catch(() => undefined);
     await this.waitForTaskListSpinnerToSettle(10_000);
@@ -301,18 +350,18 @@ export class TaskListPage extends Base {
     }
 
     const bootstrapSignal = await Promise.any([
-      this.myWorkHeading.waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS }).then(() => 'heading'),
+      this.myWorkHeading.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'heading'),
       this.taskTableTabs
         .first()
-        .waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS })
+        .waitFor({ state: 'visible', timeout: timeoutMs })
         .then(() => 'tabs'),
-      this.taskListFilterToggle.waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS }).then(() => 'filter-toggle'),
-      this.taskListTable.waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS }).then(() => 'table'),
-      this.taskTableHeader.waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS }).then(() => 'table-header'),
-      this.taskTableFooter.waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS }).then(() => 'table-footer'),
-      this.taskListResultsAmount.waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS }).then(() => 'results-summary'),
-      this.errorPageHeading.waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS }).then(() => 'error-page'),
-      this.serviceDownError.waitFor({ state: 'visible', timeout: TASK_LIST_READY_TIMEOUT_MS }).then(() => 'service-down'),
+      this.taskListFilterToggle.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'filter-toggle'),
+      this.taskListTable.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'table'),
+      this.taskTableHeader.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'table-header'),
+      this.taskTableFooter.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'table-footer'),
+      this.taskListResultsAmount.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'results-summary'),
+      this.errorPageHeading.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'error-page'),
+      this.serviceDownError.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => 'service-down'),
     ]).catch(async () => {
       const lateSignal = await findVisibleShellSignal();
       if (lateSignal) {
@@ -324,7 +373,7 @@ export class TaskListPage extends Base {
         .textContent()
         .catch(() => '');
       throw new Error(
-        `Task list shell did not become ready within ${TASK_LIST_READY_TIMEOUT_MS}ms (${context}). url=${this.page.url()} heading=${
+        `Task list shell did not become ready within ${timeoutMs}ms (${context}). url=${this.page.url()} heading=${
           headingText?.trim() || 'unknown'
         }`
       );
@@ -365,6 +414,50 @@ export class TaskListPage extends Base {
     });
   }
 
+  private async waitForFilterPanelSurface(context: string, deadlineMs?: number): Promise<boolean> {
+    const timeoutMs = this.resolveInteractionTimeout(deadlineMs, FILTER_CONTROL_READY_TIMEOUT_MS);
+
+    const panelVisible = await this.filterPanel.isVisible().catch(() => false);
+    if (!panelVisible) {
+      return false;
+    }
+
+    const surfaceReady = await Promise.any([
+      this.selectAllServicesFilter.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => true),
+      this.serviceFilterCheckboxes
+        .first()
+        .waitFor({ state: 'visible', timeout: timeoutMs })
+        .then(() => true),
+      this.selectAllTypesOfWorksFilter.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => true),
+      this.typesOfWorkFilterCheckboxes
+        .first()
+        .waitFor({ state: 'visible', timeout: timeoutMs })
+        .then(() => true),
+      this.allWorkServiceFilter.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => true),
+      this.allWorkCasesServiceFilter.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => true),
+      this.allWorkLocationAllRadio.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => true),
+      this.allWorkLocationSearchRadio.waitFor({ state: 'visible', timeout: timeoutMs }).then(() => true),
+    ]).catch(async () => {
+      await this.assertTaskListInteractive(context);
+      return false;
+    });
+
+    if (!surfaceReady) {
+      return false;
+    }
+
+    const allWorkFilterStates = await Promise.all([
+      this.allWorkServiceFilter.isVisible(),
+      this.allWorkCasesServiceFilter.isVisible(),
+    ]).catch(() => false);
+    if (Array.isArray(allWorkFilterStates) && allWorkFilterStates.some(Boolean)) {
+      return true;
+    }
+
+    const toggleText = ((await this.taskListFilterToggle.textContent().catch(() => '')) ?? '').replace(/\s+/g, ' ').trim();
+    return /Hide work filter/i.test(toggleText) && (await this.filterPanel.isVisible().catch(() => false));
+  }
+
   private async waitForFilterCheckboxVisible(checkbox: Locator, description: string, deadlineMs?: number): Promise<Locator> {
     const targetCheckbox = checkbox.first();
     const timeoutMs = this.resolveInteractionTimeout(deadlineMs, FILTER_CONTROL_READY_TIMEOUT_MS);
@@ -399,29 +492,34 @@ export class TaskListPage extends Base {
   }
 
   async openFilterPanel(deadlineMs?: number) {
-    if (await this.applyFilterButton.isVisible().catch(() => false)) {
+    if (await this.waitForFilterPanelSurface('checking existing filter panel state', deadlineMs)) {
       return;
     }
     await this.waitForTaskListSpinnerToSettle(5_000);
     this.assertFilterInteractionAlive('opening filter panel', deadlineMs);
     await this.assertTaskListInteractive('opening filter panel');
     await this.waitForFilterControls('waiting for filter controls', deadlineMs);
-    if (await this.applyFilterButton.isVisible().catch(() => false)) {
+    if (await this.waitForFilterPanelSurface('checking filter panel state after control wait', deadlineMs)) {
       return;
     }
     const panelDeadlineMs = deadlineMs ?? Date.now() + FILTER_PANEL_READY_TIMEOUT_MS;
     while (Date.now() < panelDeadlineMs) {
       this.assertFilterInteractionAlive('opening filter panel', deadlineMs);
-      if (await this.applyFilterButton.isVisible().catch(() => false)) {
+      if (await this.waitForFilterPanelSurface('waiting for filter panel surface', panelDeadlineMs)) {
         return;
       }
-      await this.taskListFilterToggle.click({ force: true });
-      await this.filterPanel
-        .waitFor({ state: 'visible', timeout: this.resolveInteractionTimeout(panelDeadlineMs, 1_000) })
-        .catch(() => undefined);
-      if (await this.applyFilterButton.isVisible().catch(() => false)) {
+
+      if (!(await this.filterPanel.isVisible().catch(() => false))) {
+        await this.taskListFilterToggle.click({ force: true });
+        await this.filterPanel
+          .waitFor({ state: 'visible', timeout: this.resolveInteractionTimeout(panelDeadlineMs, 1_000) })
+          .catch(() => undefined);
+      }
+
+      if (await this.waitForFilterPanelSurface('waiting for filter panel surface after toggle', panelDeadlineMs)) {
         return;
       }
+
       await this.page.waitForTimeout(250);
     }
     await this.assertTaskListInteractive('opening filter panel');
@@ -434,6 +532,7 @@ export class TaskListPage extends Base {
 
   async applyCurrentFilters() {
     await this.openFilterPanel();
+    await this.applyFilterButton.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
     await this.applyFilterButton.evaluate((button: HTMLButtonElement) => button.click());
   }
 
@@ -450,6 +549,15 @@ export class TaskListPage extends Base {
     });
     await this.allWorkTasksByRoleTypeFilter.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
     await this.allWorkPersonSearchInput.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
+  }
+
+  async waitForAllWorkCasesFilterControlsReady() {
+    await this.openFilterPanel();
+    await this.allWorkCasesServiceFilter.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
+    await this.allWorkCasesRoleTypeFilter.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
+    await this.allWorkPersonSearchInput.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
+    await this.allWorkLocationAllRadio.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
+    await this.allWorkLocationSearchRadio.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
   }
 
   async setSelectAllServicesFilter(checked: boolean) {
@@ -482,8 +590,13 @@ export class TaskListPage extends Base {
 
   async searchForLocation(searchText: string) {
     await this.openFilterPanel();
-    await this.allWorkLocationSearchInput.clear();
-    await this.allWorkLocationSearchInput.type(searchText);
+    await this.allWorkLocationSearchInput.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
+    await this.allWorkLocationSearchInput.click();
+    await this.allWorkLocationSearchInput.fill('');
+    await this.allWorkLocationSearchInput.type(searchText, { delay: 50 });
+    await this.allWorkLocationSearchInput.evaluate((input: HTMLInputElement) => {
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
   }
 
   private async setFilterCheckbox(checkbox: Locator, checked: boolean, description: string, deadlineMs?: number) {
@@ -554,9 +667,39 @@ export class TaskListPage extends Base {
     await this.confirmCancelTaskButton.click();
   }
 
+  async selectFirstAutocompleteOption() {
+    await this.autocompleteOverlay.last().waitFor({ state: 'visible' });
+    await this.autocompleteOverlay.last().locator('[role="option"]').first().click();
+  }
+
+  async selectAllWorkAutocompleteOption(optionText: string) {
+    const option = this.page
+      .locator('.cdk-overlay-container .mat-autocomplete-panel')
+      .getByRole('option', { name: new RegExp(escapeForRegex(optionText), 'i') })
+      .first();
+    await option.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
+    await option.click();
+  }
+
+  async applyAllWorkCasesPersonFilter(searchText: string, optionText: string) {
+    await this.waitForAllWorkCasesFilterControlsReady();
+    await this.allWorkPersonSearchInput.fill(searchText);
+    await this.selectAllWorkAutocompleteOption(optionText);
+    await this.applyFilterButton.click();
+  }
+
   async selectFirstReassignUserOption() {
-    await this.reassignUserAutocompleteOverlay.waitFor({ state: 'visible' });
-    await this.reassignUserAutocompleteFirstOption.click();
+    await this.selectFirstAutocompleteOption();
+  }
+
+  getPaginationPageControl(pageNumber: number): Locator {
+    return this.paginationControls.locator(`[aria-label="Page ${pageNumber}"]`).first();
+  }
+
+  async openPaginationPage(pageNumber: number) {
+    const pageControl = this.getPaginationPageControl(pageNumber);
+    await pageControl.waitFor({ state: 'visible', timeout: FILTER_CONTROL_READY_TIMEOUT_MS });
+    await pageControl.click();
   }
 
   async waitForManageButton(

--- a/playwright_tests_new/api/unit/ng-integration-mock-routes.unit.api.ts
+++ b/playwright_tests_new/api/unit/ng-integration-mock-routes.unit.api.ts
@@ -1,0 +1,149 @@
+import { expect, test } from '@playwright/test';
+import {
+  buildNgIntegrationClientContextMock,
+  buildNgIntegrationEnvironmentConfigMock,
+  buildNgIntegrationUserDetailsMock,
+  setupNgIntegrationBaseRoutes,
+} from '../../integration/helpers/ngIntegrationMockRoutes.helper.js';
+
+type RegisteredRoute = {
+  pattern: string | RegExp;
+  handler: (route: { fulfill: (payload: unknown) => Promise<void> }) => Promise<void>;
+};
+
+function createFakePage() {
+  const routes: RegisteredRoute[] = [];
+  const initScripts: unknown[] = [];
+
+  return {
+    initScripts,
+    routes,
+    async addInitScript(handler: unknown, args: unknown[]) {
+      initScripts.push({ handler, args });
+    },
+    async route(pattern: string | RegExp, handler: RegisteredRoute['handler']) {
+      routes.push({ pattern, handler });
+    },
+  };
+}
+
+async function invokeRoute(route: RegisteredRoute) {
+  const fulfillCalls: unknown[] = [];
+
+  await route.handler({
+    fulfill: async (payload: unknown) => {
+      fulfillCalls.push(payload);
+    },
+  });
+
+  return fulfillCalls;
+}
+
+test.describe('ng integration mock routes helper', { tag: '@svc-internal' }, () => {
+  test('builds user details with explicit role-assignment data', () => {
+    const userDetails = buildNgIntegrationUserDetailsMock({
+      userId: 'wave2-user-id',
+      roleAssignmentInfo: [{ jurisdiction: 'IA', roleType: 'ORGANISATION' }],
+      roles: ['caseworker-ia'],
+    });
+
+    expect(userDetails.userInfo).toEqual(
+      expect.objectContaining({
+        id: 'wave2-user-id',
+        uid: 'wave2-user-id',
+        roles: ['caseworker-ia'],
+      })
+    );
+    expect(userDetails.roleAssignmentInfo).toEqual([{ jurisdiction: 'IA', roleType: 'ORGANISATION' }]);
+  });
+
+  test('builds environment config with work-allocation defaults enabled', () => {
+    const environmentConfig = buildNgIntegrationEnvironmentConfigMock({
+      accessManagementEnabled: true,
+      waWorkflowApi: '/workallocation',
+    });
+
+    expect(environmentConfig).toEqual(
+      expect.objectContaining({
+        accessManagementEnabled: true,
+        waWorkflowApi: '/workallocation',
+        oidcEnabled: true,
+      })
+    );
+  });
+
+  test('seeds the expected client-context feature flags', () => {
+    const clientContext = buildNgIntegrationClientContextMock({
+      'feature-refunds': false,
+      'feature-wave2-test-flag': true,
+    });
+
+    expect(clientContext).toEqual({
+      client_context: {
+        feature_flags: expect.objectContaining({
+          MC_Work_Allocation: true,
+          'feature-refunds': false,
+          'feature-wave2-test-flag': true,
+          'mc-work-allocation-active-feature': 'WorkAllocationRelease2',
+        }),
+        user_language: {
+          language: 'en',
+        },
+      },
+    });
+  });
+
+  test('registers the base ng-integration routes and seeds session storage', async () => {
+    const fakePage = createFakePage();
+
+    await setupNgIntegrationBaseRoutes(fakePage as never, {
+      userDetails: {
+        userId: 'wave2-user-id',
+        roles: ['caseworker-ia'],
+      },
+      clientContextFeatureFlags: {
+        'feature-wave2-test-flag': true,
+      },
+    });
+
+    expect(fakePage.initScripts).toHaveLength(1);
+    expect(fakePage.routes.map(({ pattern }) => pattern)).toEqual([
+      '**/api/user/details*',
+      '**/assets/config/config.json*',
+      /\/external\/config\/ui(?:\/|\?|$)/,
+      '**/api/role-access/roles/manageLabellingRoleAssignment/**',
+      '**/api/role-access/roles/access-get-by-caseId*',
+      '**/api/wa-supported-jurisdiction/get*',
+      '**/workallocation/caseworker/getUsersByServiceName*',
+      '**/api/prd/judicial/searchJudicialUserByIdamId*',
+      '**/api/role-access/roles/getJudicialUsers*',
+      '**/api/role-access/roles/get-my-access-new-count*',
+    ]);
+
+    const fulfilledBodies = await Promise.all(fakePage.routes.map(invokeRoute));
+    const firstRoutePayload = fulfilledBodies[0][0] as { body: string };
+    const firstRouteBody = JSON.parse(firstRoutePayload.body) as {
+      userInfo?: { id?: string; roles?: string[] };
+    };
+
+    expect(firstRoutePayload).toEqual(
+      expect.objectContaining({
+        status: 200,
+        contentType: 'application/json',
+      })
+    );
+    expect(firstRouteBody.userInfo).toEqual(
+      expect.objectContaining({
+        id: 'wave2-user-id',
+        roles: ['caseworker-ia'],
+      })
+    );
+    expect(fulfilledBodies[9]).toEqual([
+      {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ count: 0 }),
+      },
+    ]);
+  });
+});

--- a/playwright_tests_new/api/unit/task-list-bootstrap.unit.api.ts
+++ b/playwright_tests_new/api/unit/task-list-bootstrap.unit.api.ts
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/test';
+import {
+  buildSupportedJurisdictionDetails,
+  setupTaskListBootstrapRoutes,
+} from '../../integration/helpers/taskListMockRoutes.helper.js';
+
+type RegisteredRoute = {
+  pattern: string | RegExp;
+  handler: (route: { fulfill: (payload: unknown) => Promise<void> }) => Promise<void>;
+};
+
+function createFakePage() {
+  const routes: RegisteredRoute[] = [];
+
+  return {
+    routes,
+    async route(pattern: string | RegExp, handler: RegisteredRoute['handler']) {
+      routes.push({ pattern, handler });
+    },
+  };
+}
+
+function getRegisteredRoute(routes: RegisteredRoute[], pattern: string | RegExp) {
+  return routes.find((route) => route.pattern === pattern);
+}
+
+async function invokeRoute(route: RegisteredRoute) {
+  const fulfillCalls: unknown[] = [];
+
+  await route.handler({
+    fulfill: async (payload: unknown) => {
+      fulfillCalls.push(payload);
+    },
+  });
+
+  return fulfillCalls;
+}
+
+test.describe('task list bootstrap routes helper', { tag: '@svc-internal' }, () => {
+  test('fills in supported jurisdiction display names from the shared defaults', () => {
+    expect(buildSupportedJurisdictionDetails(['IA', 'SSCS', 'UNKNOWN'])).toEqual([
+      { serviceId: 'IA', serviceName: 'Immigration and Asylum' },
+      { serviceId: 'SSCS', serviceName: 'Social security and child support' },
+      { serviceId: 'UNKNOWN', serviceName: 'UNKNOWN' },
+    ]);
+  });
+
+  test('uses resolved service names for the bootstrap routes when explicit details are omitted', async () => {
+    const fakePage = createFakePage();
+
+    await setupTaskListBootstrapRoutes(fakePage as never, ['IA', 'CIVIL']);
+
+    const detailedServicesRoute = getRegisteredRoute(fakePage.routes, '**/api/wa-supported-jurisdiction/detail*');
+    const aggregatedJurisdictionsRoute = getRegisteredRoute(fakePage.routes, '**/aggregated/caseworkers/**/jurisdictions*');
+
+    expect(detailedServicesRoute).toBeTruthy();
+    expect(aggregatedJurisdictionsRoute).toBeTruthy();
+
+    const detailedServicesPayload = (await invokeRoute(detailedServicesRoute!))[0] as { body: string };
+    const aggregatedJurisdictionsPayload = (await invokeRoute(aggregatedJurisdictionsRoute!))[0] as { body: string };
+
+    expect(JSON.parse(detailedServicesPayload.body)).toEqual([
+      { serviceId: 'IA', serviceName: 'Immigration and Asylum' },
+      { serviceId: 'CIVIL', serviceName: 'Civil' },
+    ]);
+    expect(JSON.parse(aggregatedJurisdictionsPayload.body)).toEqual([
+      { id: 'IA', name: 'Immigration and Asylum' },
+      { id: 'CIVIL', name: 'Civil' },
+    ]);
+  });
+
+  test('keeps caller-supplied service labels ahead of the shared defaults', async () => {
+    const fakePage = createFakePage();
+
+    await setupTaskListBootstrapRoutes(fakePage as never, ['IA', 'SSCS'], [{ serviceId: 'IA', serviceName: 'Custom IA' }]);
+
+    const detailedServicesRoute = getRegisteredRoute(fakePage.routes, '**/api/wa-supported-jurisdiction/detail*');
+    const aggregatedJurisdictionsRoute = getRegisteredRoute(fakePage.routes, '**/aggregated/caseworkers/**/jurisdictions*');
+
+    expect(detailedServicesRoute).toBeTruthy();
+    expect(aggregatedJurisdictionsRoute).toBeTruthy();
+
+    const detailedServicesPayload = (await invokeRoute(detailedServicesRoute!))[0] as { body: string };
+    const aggregatedJurisdictionsPayload = (await invokeRoute(aggregatedJurisdictionsRoute!))[0] as { body: string };
+
+    expect(JSON.parse(detailedServicesPayload.body)).toEqual([
+      { serviceId: 'IA', serviceName: 'Custom IA' },
+      { serviceId: 'SSCS', serviceName: 'Social security and child support' },
+    ]);
+    expect(JSON.parse(aggregatedJurisdictionsPayload.body)).toEqual([
+      { id: 'IA', name: 'Custom IA' },
+      { id: 'SSCS', name: 'Social security and child support' },
+    ]);
+  });
+});

--- a/playwright_tests_new/integration/helpers/index.ts
+++ b/playwright_tests_new/integration/helpers/index.ts
@@ -13,6 +13,7 @@ export { applySessionCookies } from '../../common/sessionCapture';
 export * from './searchCaseSession.helper';
 export * from './hearingsMockRoutes.helper';
 export * from './hearingJourneySetup.helper';
+export * from './ngIntegrationMockRoutes.helper';
 export * from './taskListMockRoutes.helper';
 export * from './bookingUiMockRoutes.helper';
 export * from './manageTasksMockRoutes.helper';

--- a/playwright_tests_new/integration/helpers/manageTasksMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/manageTasksMockRoutes.helper.ts
@@ -4,6 +4,7 @@ import { setupTaskListBootstrapRoutes, taskListRoutePattern } from './taskListMo
 
 export const myCasesRoutePattern = /\/workallocation\/my-work\/cases(?:\?.*)?$/;
 export const myAccessRoutePattern = /\/workallocation\/my-work\/myaccess(?:\?.*)?$/;
+export const allWorkCasesRoutePattern = /\/workallocation\/all-work\/cases(?:\?.*)?$/;
 
 const defaultTaskListResponse = { tasks: [], total_records: 0 };
 
@@ -52,12 +53,18 @@ export async function setupManageTasksBaseRoutes(page: Page, options: BaseManage
 
 type MyCasesRouteOptions = BaseManageTaskRouteOptions & {
   status?: number;
+  routeHandler?: (route: Route) => Promise<void>;
 };
 
 export async function setupMyCasesRoutes(page: Page, myCasesResponse: unknown, options: MyCasesRouteOptions = {}): Promise<void> {
   await setupManageTasksBaseRoutes(page, options);
 
   await page.route(myCasesRoutePattern, async (route) => {
+    if (options.routeHandler) {
+      await options.routeHandler(route);
+      return;
+    }
+
     await route.fulfill({
       status: options.status ?? 200,
       contentType: 'application/json',
@@ -91,6 +98,32 @@ export async function setupMyAccessRoutes(
       status: options.status ?? 200,
       contentType: 'application/json',
       body: JSON.stringify(myAccessResponse),
+    });
+  });
+}
+
+type AllWorkCasesRouteOptions = BaseManageTaskRouteOptions & {
+  status?: number;
+  routeHandler?: (route: Route) => Promise<void>;
+};
+
+export async function setupAllWorkCasesRoutes(
+  page: Page,
+  allWorkCasesResponse: unknown,
+  options: AllWorkCasesRouteOptions = {}
+): Promise<void> {
+  await setupManageTasksBaseRoutes(page, options);
+
+  await page.route(allWorkCasesRoutePattern, async (route) => {
+    if (options.routeHandler) {
+      await options.routeHandler(route);
+      return;
+    }
+
+    await route.fulfill({
+      status: options.status ?? 200,
+      contentType: 'application/json',
+      body: JSON.stringify(allWorkCasesResponse),
     });
   });
 }

--- a/playwright_tests_new/integration/helpers/ngIntegrationMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/ngIntegrationMockRoutes.helper.ts
@@ -1,0 +1,193 @@
+import { createRequire } from 'node:module';
+import type { Page } from '@playwright/test';
+
+const require = createRequire(import.meta.url);
+
+const appConfigTemplate = require('../../../src/assets/config/config.json');
+const headerConfigTemplate = require('../../../test_codecept/ngIntegration/config/baseConfig.js');
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface NgIntegrationUserDetailsOptions {
+  userId?: string;
+  forename?: string;
+  surname?: string;
+  email?: string;
+  roleCategory?: string;
+  roles?: string[];
+  roleAssignmentInfo?: UnknownRecord[];
+}
+
+export interface NgIntegrationEnvironmentConfigOptions {
+  accessManagementEnabled?: boolean;
+  ccdGatewayUrl?: string;
+  headerConfig?: UnknownRecord;
+  launchDarklyClientId?: string;
+  waWorkflowApi?: string;
+}
+
+export interface NgIntegrationBaseRoutesOptions {
+  userDetails?: NgIntegrationUserDetailsOptions;
+  environmentConfig?: NgIntegrationEnvironmentConfigOptions;
+  clientContextFeatureFlags?: Record<string, unknown>;
+}
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function buildNgIntegrationUserDetailsMock(options?: NgIntegrationUserDetailsOptions) {
+  const roles = options?.roles ?? ['caseworker-ia-caseofficer', 'caseworker-ia-admofficer'];
+  const userId = options?.userId ?? 'wave2-user-id';
+
+  return {
+    sessionTimeout: {
+      idleModalDisplayTime: 300,
+      totalIdleTime: 900,
+    },
+    canShareCases: false,
+    userInfo: {
+      id: userId,
+      uid: userId,
+      forename: options?.forename ?? 'Wave2',
+      surname: options?.surname ?? 'Playwright',
+      email: options?.email ?? 'wave2.playwright@justice.gov.uk',
+      active: true,
+      roleCategory: options?.roleCategory ?? 'LEGAL_OPERATIONS',
+      roles,
+    },
+    roleAssignmentInfo: deepClone(options?.roleAssignmentInfo ?? []),
+  };
+}
+
+export function buildNgIntegrationAppConfigMock(): UnknownRecord {
+  return deepClone(appConfigTemplate) as UnknownRecord;
+}
+
+export function buildNgIntegrationEnvironmentConfigMock(options?: NgIntegrationEnvironmentConfigOptions): UnknownRecord {
+  return {
+    accessManagementEnabled: options?.accessManagementEnabled ?? true,
+    ccdGatewayUrl: options?.ccdGatewayUrl ?? 'http://localhost:3001',
+    clientId: 'xui-webapp',
+    idamWeb: 'https://idam-web-public.aat.platform.hmcts.net',
+    launchDarklyClientId: options?.launchDarklyClientId ?? '5de6610b23ce5408280f2268',
+    oAuthCallback: '/oauth2/callback',
+    oidcEnabled: true,
+    protocol: 'http',
+    waWorkflowApi: options?.waWorkflowApi ?? '/workallocation',
+    headerConfig: options?.headerConfig ?? deepClone(headerConfigTemplate),
+  };
+}
+
+export function buildNgIntegrationClientContextMock(featureFlags?: Record<string, unknown>): UnknownRecord {
+  return {
+    client_context: {
+      feature_flags: {
+        MC_Work_Allocation: true,
+        MC_Notice_of_Change: true,
+        'feature-global-search': true,
+        'feature-refunds': true,
+        'mc-work-allocation-active-feature': 'WorkAllocationRelease2',
+        ...featureFlags,
+      },
+      user_language: {
+        language: 'en',
+      },
+    },
+  };
+}
+
+export async function setupNgIntegrationBaseRoutes(page: Page, options?: NgIntegrationBaseRoutesOptions): Promise<void> {
+  const userDetails = buildNgIntegrationUserDetailsMock(options?.userDetails);
+  const appConfig = buildNgIntegrationAppConfigMock();
+  const environmentConfig = buildNgIntegrationEnvironmentConfigMock(options?.environmentConfig);
+  const clientContext = buildNgIntegrationClientContextMock(options?.clientContextFeatureFlags);
+
+  await page.addInitScript(
+    ([seededUserInfo, seededClientContext]) => {
+      window.sessionStorage.setItem('userDetails', JSON.stringify(seededUserInfo));
+      window.sessionStorage.setItem('clientContext', JSON.stringify(seededClientContext));
+    },
+    [userDetails.userInfo, clientContext]
+  );
+
+  await page.route('**/api/user/details*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(userDetails),
+    });
+  });
+
+  await page.route('**/assets/config/config.json*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(appConfig),
+    });
+  });
+
+  await page.route(/\/external\/config\/ui(?:\/|\?|$)/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(environmentConfig),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/manageLabellingRoleAssignment/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/access-get-by-caseId*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/api/wa-supported-jurisdiction/get*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/api/prd/judicial/searchJudicialUserByIdamId*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/getJudicialUsers*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
+  await page.route('**/api/role-access/roles/get-my-access-new-count*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ count: 0 }),
+    });
+  });
+}

--- a/playwright_tests_new/integration/helpers/taskListMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/taskListMockRoutes.helper.ts
@@ -14,15 +14,46 @@ type TaskMockRouteOptions = {
 
 const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-const defaultSupportedJurisdictionDetailsMock: SupportedJurisdictionDetail[] = defaultSupportedJurisdictionsMock.map(
-  (serviceId) => ({ serviceId, serviceName: serviceId })
+const supportedJurisdictionDisplayNames: Record<string, string> = {
+  CIVIL: 'Civil',
+  EMPLOYMENT: 'Employment',
+  IA: 'Immigration and Asylum',
+  PRIVATELAW: 'Private Law',
+  PUBLICLAW: 'Public Law',
+  SSCS: 'Social security and child support',
+};
+
+export function buildSupportedJurisdictionDetails(
+  supportedJurisdictions: string[],
+  supportedJurisdictionDetails: SupportedJurisdictionDetail[] = []
+): SupportedJurisdictionDetail[] {
+  return supportedJurisdictions.map((serviceId) => {
+    const explicitDetail = supportedJurisdictionDetails.find((detail) => detail.serviceId === serviceId);
+    return explicitDetail ?? { serviceId, serviceName: supportedJurisdictionDisplayNames[serviceId] ?? serviceId };
+  });
+}
+
+export const defaultSupportedJurisdictionDetailsMock: SupportedJurisdictionDetail[] = buildSupportedJurisdictionDetails(
+  defaultSupportedJurisdictionsMock
 );
 
 export async function setupTaskListBootstrapRoutes(
   page: Page,
   supportedJurisdictions: string[] = defaultSupportedJurisdictionsMock,
-  supportedJurisdictionDetails: SupportedJurisdictionDetail[] = defaultSupportedJurisdictionDetailsMock
+  supportedJurisdictionDetails: SupportedJurisdictionDetail[] = []
 ): Promise<void> {
+  const resolvedSupportedJurisdictionDetails = buildSupportedJurisdictionDetails(
+    supportedJurisdictions,
+    supportedJurisdictionDetails
+  );
+  const aggregatedJurisdictions = supportedJurisdictions.map((serviceId) => {
+    const detailedService = resolvedSupportedJurisdictionDetails.find((service) => service.serviceId === serviceId);
+    return {
+      id: serviceId,
+      name: detailedService?.serviceName ?? serviceId,
+    };
+  });
+
   await page.route('**/api/wa-supported-jurisdiction/get*', async (route) => {
     await route.fulfill({
       status: 200,
@@ -35,7 +66,15 @@ export async function setupTaskListBootstrapRoutes(
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(supportedJurisdictionDetails),
+      body: JSON.stringify(resolvedSupportedJurisdictionDetails),
+    });
+  });
+
+  await page.route('**/aggregated/caseworkers/**/jurisdictions*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(aggregatedJurisdictions),
     });
   });
 


### PR DESCRIPTION
### Jira link

See [EXUI-4534](https://tools.hmcts.net/jira/browse/EXUI-4534)

### Change description

This PR adds the shared Playwright integration foundation needed before the remaining Work Allocation parity scenarios are split into smaller PRs.

- Adds reusable manage-tasks route setup helpers for the integration test harness.
- Adds shared task-list and ngIntegration mock route support used by the follow-on Work Allocation slices.
- Adds direct API/unit coverage for the shared mock-route and task-list bootstrap behaviour so the support code is tested without relying only on browser specs.
- Extends the task-list page object with reusable interactions needed by the parity slices.

Value to the test pack:

- Gives the Work Allocation Playwright integration tests a common, reviewed foundation rather than duplicating route setup in each spec.
- Improves maintainability by centralising mock contracts for manage-tasks flows.
- Reduces review risk for the follow-on slices because each functional PR can focus on one area of behaviour.
- Adds fast support-code coverage for the mocked integration seams that would otherwise fail late in browser execution.

### Dependency PRs

N/A - this is the base PR for the stacked Work Allocation parity slices.

### Testing done

Automated:

- [x] `git diff --check` passed for the split branch.
- [ ] `yarn lint` not run after branch split.
- [ ] Focused Playwright integration tests not run after branch split.

Manual:

- [x] Reviewed the split to confirm this branch contains the shared support layer only.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
