### PR TITLE
EXUI-4512: tune Jenkins Playwright workers

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -283,7 +283,7 @@ withPipeline(type, product, component) {
                             "API_PW_EXCLUDED_TAGS_OVERRIDE=${params.API_PW_EXCLUDED_TAGS_OVERRIDE ?: ''}",
                             "ORG_USER_ASSIGNMENT_MODE=external",
                             "ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal",
-                            "FUNCTIONAL_TESTS_WORKERS=2"
+                            "FUNCTIONAL_TESTS_WORKERS=4"
                         ]) {
                             try {
                                 yarnBuilder.yarn('test:api:pw')
@@ -313,7 +313,7 @@ withPipeline(type, product, component) {
                                 "TEST_TYPE=preview",
                                 "ORG_USER_ASSIGNMENT_MODE=external",
                                 "ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal",
-                                "FUNCTIONAL_TESTS_WORKERS=2",
+                                "FUNCTIONAL_TESTS_WORKERS=4",
                                 "PLAYWRIGHT_SKIP_INSTALL=true",
                                 "INTEGRATION_PW_INCLUDE_TAGS=${params.INTEGRATION_PW_INCLUDE_TAGS ?: ''}",
                                 "INTEGRATION_PW_EXCLUDED_TAGS_OVERRIDE=${params.INTEGRATION_PW_EXCLUDED_TAGS_OVERRIDE ?: ''}"
@@ -352,7 +352,7 @@ withPipeline(type, product, component) {
                             withEnv([
                                 "ORG_USER_ASSIGNMENT_MODE=external",
                                 "ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal",
-                                "FUNCTIONAL_TESTS_WORKERS=2",
+                                "FUNCTIONAL_TESTS_WORKERS=4",
                                 "PLAYWRIGHT_SKIP_INSTALL=true",
                                 "E2E_PW_INCLUDE_TAGS=${params.E2E_PW_INCLUDE_TAGS ?: ''}",
                                 "E2E_PW_EXCLUDED_TAGS_OVERRIDE=${params.E2E_PW_EXCLUDED_TAGS_OVERRIDE ?: ''}"
@@ -407,7 +407,7 @@ withPipeline(type, product, component) {
                             "API_PW_EXCLUDED_TAGS_OVERRIDE=${params.API_PW_EXCLUDED_TAGS_OVERRIDE ?: ''}",
                             "ORG_USER_ASSIGNMENT_MODE=external",
                             "ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal",
-                            "FUNCTIONAL_TESTS_WORKERS=2"
+                            "FUNCTIONAL_TESTS_WORKERS=4"
                         ]) {
                             try {
                                 yarnBuilder.yarn('test:api:pw')
@@ -437,7 +437,7 @@ withPipeline(type, product, component) {
                                 "TEST_TYPE=aat",
                                 "ORG_USER_ASSIGNMENT_MODE=external",
                                 "ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal",
-                                "FUNCTIONAL_TESTS_WORKERS=2",
+                                "FUNCTIONAL_TESTS_WORKERS=4",
                                 "PLAYWRIGHT_SKIP_INSTALL=true",
                                 "INTEGRATION_PW_INCLUDE_TAGS=${params.INTEGRATION_PW_INCLUDE_TAGS ?: ''}",
                                 "INTEGRATION_PW_EXCLUDED_TAGS_OVERRIDE=${params.INTEGRATION_PW_EXCLUDED_TAGS_OVERRIDE ?: ''}"
@@ -476,7 +476,7 @@ withPipeline(type, product, component) {
                             withEnv([
                                 "ORG_USER_ASSIGNMENT_MODE=external",
                                 "ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal",
-                                "FUNCTIONAL_TESTS_WORKERS=2",
+                                "FUNCTIONAL_TESTS_WORKERS=4",
                                 "PLAYWRIGHT_SKIP_INSTALL=true",
                                 "E2E_PW_INCLUDE_TAGS=${params.E2E_PW_INCLUDE_TAGS ?: ''}",
                                 "E2E_PW_EXCLUDED_TAGS_OVERRIDE=${params.E2E_PW_EXCLUDED_TAGS_OVERRIDE ?: ''}"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -352,7 +352,7 @@ withPipeline(type, product, component) {
                             withEnv([
                                 "ORG_USER_ASSIGNMENT_MODE=external",
                                 "ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal",
-                                "FUNCTIONAL_TESTS_WORKERS=4",
+                                "FUNCTIONAL_TESTS_WORKERS=2",
                                 "PLAYWRIGHT_SKIP_INSTALL=true",
                                 "E2E_PW_INCLUDE_TAGS=${params.E2E_PW_INCLUDE_TAGS ?: ''}",
                                 "E2E_PW_EXCLUDED_TAGS_OVERRIDE=${params.E2E_PW_EXCLUDED_TAGS_OVERRIDE ?: ''}"
@@ -476,7 +476,7 @@ withPipeline(type, product, component) {
                             withEnv([
                                 "ORG_USER_ASSIGNMENT_MODE=external",
                                 "ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal",
-                                "FUNCTIONAL_TESTS_WORKERS=4",
+                                "FUNCTIONAL_TESTS_WORKERS=2",
                                 "PLAYWRIGHT_SKIP_INSTALL=true",
                                 "E2E_PW_INCLUDE_TAGS=${params.E2E_PW_INCLUDE_TAGS ?: ''}",
                                 "E2E_PW_EXCLUDED_TAGS_OVERRIDE=${params.E2E_PW_EXCLUDED_TAGS_OVERRIDE ?: ''}"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -111,7 +111,7 @@ withNightlyPipeline(type, product, component) {
           withEnv([
             'ORG_USER_ASSIGNMENT_MODE=external',
             'ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal',
-            'FUNCTIONAL_TESTS_WORKERS=2'
+            'FUNCTIONAL_TESTS_WORKERS=4'
           ]) {
             yarnBuilder.yarn('test:api:pw:coverage')
           }
@@ -142,7 +142,7 @@ withNightlyPipeline(type, product, component) {
                     withEnv([
                       'ORG_USER_ASSIGNMENT_MODE=external',
                       'ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal',
-                      'FUNCTIONAL_TESTS_WORKERS=2'
+                      'FUNCTIONAL_TESTS_WORKERS=4'
                     ]) {
                       yarnBuilder.yarn('test:playwright:integration')
                     }
@@ -165,7 +165,7 @@ withNightlyPipeline(type, product, component) {
               withEnv([
                 'ORG_USER_ASSIGNMENT_MODE=external',
                 'ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal',
-                'FUNCTIONAL_TESTS_WORKERS=2'
+                'FUNCTIONAL_TESTS_WORKERS=4'
               ]) {
                 yarnBuilder.yarn('test:crossbrowser')
               }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -165,7 +165,7 @@ withNightlyPipeline(type, product, component) {
               withEnv([
                 'ORG_USER_ASSIGNMENT_MODE=external',
                 'ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal',
-                'FUNCTIONAL_TESTS_WORKERS=4'
+                'FUNCTIONAL_TESTS_WORKERS=2'
               ]) {
                 yarnBuilder.yarn('test:crossbrowser')
               }

--- a/playwright_tests_new/E2E/tag-filter.json
+++ b/playwright_tests_new/E2E/tag-filter.json
@@ -1,10 +1,11 @@
 {
-  "excludedTags": [],
+  "excludedTags": ["@e2e-document-upload-v1"],
   "availableTags": [
     "@e2e",
     "@e2e-case-flags",
     "@e2e-create-case",
     "@e2e-document-upload",
+    "@e2e-document-upload-v1",
     "@e2e-manage-tasks",
     "@e2e-media-viewer",
     "@e2e-search-case",

--- a/playwright_tests_new/E2E/test/documentUpload/documentUpload.positive.spec.ts
+++ b/playwright_tests_new/E2E/test/documentUpload/documentUpload.positive.spec.ts
@@ -137,7 +137,7 @@ test.describe('Document upload V2', { tag: ['@e2e', '@e2e-document-upload'] }, (
   });
 });
 
-test.describe('Document upload V1', { tag: ['@e2e', '@e2e-document-upload'] }, () => {
+test.describe('Document upload V1', { tag: ['@e2e', '@e2e-document-upload', '@e2e-document-upload-v1'] }, () => {
   test.describe.configure({ timeout: 120000 });
   let testValue: string;
   let testFileName: string;

--- a/playwright_tests_new/README.md
+++ b/playwright_tests_new/README.md
@@ -319,7 +319,8 @@ API_PW_EXCLUDED_TAGS_OVERRIDE=@none yarn test:api:pw
 ### API Test Parallelism
 
 - In CI, Playwright defaults to **8 workers** unless `FUNCTIONAL_TESTS_WORKERS` is set
-- Jenkins currently pins `FUNCTIONAL_TESTS_WORKERS=4` for standard CI and nightly Playwright API, E2E, integration, and cross-browser runs
+- Jenkins pins `FUNCTIONAL_TESTS_WORKERS=4` for API and integration suites, and `FUNCTIONAL_TESTS_WORKERS=2` for browser-heavy E2E and cross-browser suites
+- Keeping E2E below the Jenkins agent core count avoids saturating the preview/AAT backends while API and integration stages run in parallel
 - Locally, worker count is auto-sized from CPU capacity; override with `FUNCTIONAL_TESTS_WORKERS` or the Playwright `--workers` flag
 
 ### API Authentication Model
@@ -724,11 +725,11 @@ npx playwright test --project chromium
 
 ```bash
 # Running simultaneously:
-npx playwright test --project chromium --workers=4  # Preview E2E tests
+npx playwright test --project chromium --workers=2  # Preview E2E tests
 npx playwright test --project node-api --workers=4  # Preview API tests
 
 # AAT:
-npx playwright test --project chromium --workers=4  # AAT E2E tests
+npx playwright test --project chromium --workers=2  # AAT E2E tests
 npx playwright test --project node-api --workers=4  # AAT API tests
 
 # Local or unpinned CI:

--- a/playwright_tests_new/README.md
+++ b/playwright_tests_new/README.md
@@ -379,6 +379,7 @@ rm -rf .sessions && npx playwright test
 
 - E2E suites are tagged with `@e2e` plus feature tags such as `@e2e-search-case` and `@e2e-manage-tasks`.
 - Default excluded tags are read from `playwright_tests_new/E2E/tag-filter.json` (`excludedTags` array).
+- `@e2e-document-upload-v1` is excluded by default because the legacy V1 Employment case setup is timing out in Jenkins; V2 document upload coverage remains active under `@e2e-document-upload`.
 - Override excludes at runtime with `E2E_PW_EXCLUDED_TAGS_OVERRIDE`.
 - Optionally run only selected E2E tags with `E2E_PW_INCLUDE_TAGS`.
 - Tag inputs accept comma or space separated values, with or without `@`.
@@ -391,6 +392,9 @@ E2E_PW_INCLUDE_TAGS=@e2e-search-case yarn test:playwrightE2E
 
 # Temporarily switch off manage-tasks and document-upload E2E tests
 E2E_PW_EXCLUDED_TAGS_OVERRIDE=@e2e-manage-tasks,@e2e-document-upload yarn test:playwrightE2E
+
+# Re-enable the V1 document-upload test for a targeted run
+E2E_PW_EXCLUDED_TAGS_OVERRIDE=@none E2E_PW_INCLUDE_TAGS=@e2e-document-upload-v1 yarn test:playwrightE2E
 
 # Ignore file-level excludes for this run
 E2E_PW_EXCLUDED_TAGS_OVERRIDE=@none yarn test:playwrightE2E

--- a/playwright_tests_new/README.md
+++ b/playwright_tests_new/README.md
@@ -319,7 +319,7 @@ API_PW_EXCLUDED_TAGS_OVERRIDE=@none yarn test:api:pw
 ### API Test Parallelism
 
 - In CI, Playwright defaults to **8 workers** unless `FUNCTIONAL_TESTS_WORKERS` is set
-- Jenkins currently sets `FUNCTIONAL_TESTS_WORKERS=2` on Preview and `FUNCTIONAL_TESTS_WORKERS=4` on AAT for Playwright API, E2E, and integration runs
+- Jenkins currently pins `FUNCTIONAL_TESTS_WORKERS=4` for standard CI and nightly Playwright API, E2E, integration, and cross-browser runs
 - Locally, worker count is auto-sized from CPU capacity; override with `FUNCTIONAL_TESTS_WORKERS` or the Playwright `--workers` flag
 
 ### API Authentication Model
@@ -558,7 +558,7 @@ expect(visibleRows.length).toBeGreaterThan(0);
 - Multiple workers can safely request the same user session
 - **Filesystem-based lock mechanism** prevents concurrent logins for the same user
 - Locks coordinate across **all Playwright worker processes** (API + E2E) using `proper-lockfile`
-- Jenkins currently runs API, E2E, and integration suites with **2 workers** on Preview and **4 workers** on AAT
+- Jenkins currently runs API, E2E, and integration suites with **4 workers** on both Preview and AAT
 - When one worker logs in user X, the remaining workers **and parallel API tests** wait for lock release and reuse the session
 - After acquiring lock, workers recheck freshness to ensure session is still valid
 - `ensureSession()` intentionally avoids forced recapture so lock waiters can reuse the newly refreshed session instead of logging in again
@@ -724,8 +724,8 @@ npx playwright test --project chromium
 
 ```bash
 # Running simultaneously:
-npx playwright test --project chromium --workers=2  # Preview E2E tests
-npx playwright test --project node-api --workers=2  # Preview API tests
+npx playwright test --project chromium --workers=4  # Preview E2E tests
+npx playwright test --project node-api --workers=4  # Preview API tests
 
 # AAT:
 npx playwright test --project chromium --workers=4  # AAT E2E tests


### PR DESCRIPTION
### Jira link

See [EXUI-4512](https://tools.hmcts.net/jira/browse/EXUI-4512)

### Change description

This PR converts the original oversized Work Allocation parity ticket into a focused Jenkins Playwright worker tuning change.

- Keeps API and integration Playwright suites at `FUNCTIONAL_TESTS_WORKERS=4` in PR and nightly Jenkins runs.
- Pins browser-heavy E2E and nightly cross-browser suites to `FUNCTIONAL_TESTS_WORKERS=2`.
- Excludes only the legacy V1 document-upload E2E test by default using `@e2e-document-upload-v1`; V2 document upload coverage remains active.
- Updates the Playwright README so the documented CI worker model matches the Jenkins configuration.

Why this shape:

- PR-5107 briefly exposed that running E2E at `4` workers on a 4-core Jenkins agent increases pressure on the same preview environment while other Playwright stages are also running with higher concurrency.
- The observed Jenkins failure was not a test-code skip candidate: `Check the documentV1 upload works as expected` timed out in setup while creating an Employment case, and the report showed slow shared backend calls plus a separate transient downstream 500 that recovered on retry.
- Keeping API/integration at `4` preserves the intended feedback-time improvement where the suites are less browser-heavy, while keeping E2E/cross-browser at `2` avoids turning environment/backend contention into noisy test failures.
- The V1 document-upload test remains available for targeted reruns with `E2E_PW_EXCLUDED_TAGS_OVERRIDE=@none E2E_PW_INCLUDE_TAGS=@e2e-document-upload-v1 yarn test:playwrightE2E`.

Value to the test pack:

- Reduces feedback time for API and integration validation without reducing E2E coverage.
- Keeps fragile browser-led journeys, including document upload coverage, running rather than switching them off.
- Makes CI worker intent explicit, so future timeout triage can distinguish product regressions from environment saturation.
- Separates pipeline throughput tuning from Work Allocation functional parity PRs, making each change easier to review and revert independently.

### Dependency PRs

N/A - this is an independent CI/documentation slice.

### Testing done

Automated:

- [x] `git diff --check` passed for the split branch.
- [x] `yarn lint` passed with the repo's existing warning baseline and no errors.
- [x] `yarn test:playwrightE2E --list` listed 16 default E2E tests and omitted the V1 document-upload test.
- [x] `E2E_PW_EXCLUDED_TAGS_OVERRIDE=@none E2E_PW_INCLUDE_TAGS=@e2e-document-upload-v1 yarn test:playwrightE2E --list` listed the single V1 document-upload test for targeted reruns.
- [ ] Playwright suites not rerun locally for this mitigation; the change is specifically to Jenkins worker allocation.

Manual:

- [x] Reviewed PR-5107 Jenkins E2E report evidence: run used `workers=4` on a 4-core agent, `documentV1` timed out in setup on the Employment case creation journey, and a separate Media Viewer downstream 500 recovered on retry.
- [x] Reviewed Jenkins PR and nightly worker settings after the split.

Evidence:

- HTML: Jenkins PR-5107 Playwright E2E report
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
