### PR TITLE
EXUI-4536: add All Work task-navigation Playwright tests

### DIFF
--- a/playwright_tests_new/integration/mocks/myCases.mock.ts
+++ b/playwright_tests_new/integration/mocks/myCases.mock.ts
@@ -21,6 +21,7 @@ export type MyCaseMock = {
   case_role: string;
   role: string;
   role_category: string;
+  assignee: string;
   hasAccess: boolean;
   actions: MyCaseActionMock[];
 };
@@ -66,7 +67,7 @@ export const myCaseDisplayValues = [...new Set(myCaseStateDefinitions.map((defin
 
 export const buildMyCaseMock = (overrides: Partial<MyCaseMock> = {}): MyCaseMock => {
   const serviceLabelByJurisdiction: Record<string, string> = {
-    IA: 'Immigration & Asylum',
+    IA: 'Immigration and Asylum',
     SSCS: 'Social security and child support',
     Other: 'Other',
   };
@@ -91,6 +92,7 @@ export const buildMyCaseMock = (overrides: Partial<MyCaseMock> = {}): MyCaseMock
     case_role: overrides.case_role ?? stateDefinition.caseRole,
     role: overrides.role ?? stateDefinition.role,
     role_category: overrides.role_category ?? stateDefinition.roleCategory,
+    assignee: overrides.assignee ?? faker.string.uuid(),
     hasAccess: overrides.hasAccess ?? true,
     actions: overrides.actions ?? [...myCasesNoActions],
   };
@@ -126,13 +128,14 @@ export const buildMyCasesMock = (uniqueCasesCount: number = 2): MyCasesResponseM
       case_type: 'Asylum',
       jurisdiction: 'IA',
       jurisdictionId: 'IA',
-      expectedServiceLabel: 'Immigration & Asylum',
+      expectedServiceLabel: 'Immigration and Asylum',
       startDate: toMiddayUtcIso('2026-01-10T00:00:00.000Z'),
       endDate: toMiddayUtcIso('2026-02-16T00:00:00.000Z'),
       next_hearing_date: toMiddayUtcIso('2026-01-20T00:00:00.000Z'),
       case_role: 'lead-judge',
       role: 'Lead Judge',
       role_category: 'JUDICIAL',
+      assignee: 'judicial-assignee-1',
       hasAccess: true,
       actions: myCasesAllocatorActions,
     }),
@@ -151,6 +154,7 @@ export const buildMyCasesMock = (uniqueCasesCount: number = 2): MyCasesResponseM
       case_role: 'case-manager',
       role: 'Case Manager',
       role_category: 'LEGAL_OPERATIONS',
+      assignee: 'legal-ops-assignee-2',
       hasAccess: true,
       actions: myCasesNoActions,
     }),

--- a/playwright_tests_new/integration/test/manageTasks/allWork/allWorkTasks.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/allWork/allWorkTasks.positive.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '../../../../E2E/fixtures';
 import { applySessionCookies, setupManageTasksBaseRoutes, taskListRoutePattern } from '../../../helpers';
+import { buildCaseDetailsTasksFromParams } from '../../../mocks/caseDetailsTasks.builder';
+import { buildAsylumCaseMock } from '../../../mocks/cases/asylumCase.mock';
 import { buildTaskListMock, myActionsList } from '../../../mocks/taskList.mock';
 import { buildMyCases } from '../../../mocks/myCases.mock';
 
@@ -19,12 +21,85 @@ test.describe(`All Work Tasks as ${userIdentifier}`, { tag: ['@integration', '@i
 
   test('User can view all-work task table, links, and pagination', async ({ taskListPage, page, tableUtils }) => {
     const taskListMockResponse = buildTaskListMock(2000, '', myActionsList);
+    const firstTask = taskListMockResponse.tasks[0];
+
+    firstTask.case_name = 'All work migrated case';
+    firstTask.case_name_field = firstTask.case_name;
+    firstTask.task_title = 'All work migrated task';
+    firstTask.task_field = firstTask.task_title;
+
+    const caseMockResponse = buildAsylumCaseMock({
+      caseId: firstTask.case_id,
+      caseTypeId: firstTask.case_type_id,
+      jurisdictionId: firstTask.jurisdiction,
+    });
+    const caseTasksResponse = buildCaseDetailsTasksFromParams({
+      caseId: firstTask.case_id,
+      tasks: [
+        {
+          id: firstTask.id,
+          title: firstTask.task_title,
+          state: 'assigned',
+          assignee: 'all-work-assignee-1',
+          createdDate: firstTask.created_date,
+          dueDate: firstTask.due_date,
+          priorityDate: firstTask.priority_date,
+          jurisdiction: firstTask.jurisdiction,
+          caseTypeId: firstTask.case_type_id,
+          caseId: firstTask.case_id,
+          caseName: firstTask.case_name,
+          caseCategory: firstTask.case_category,
+          locationName: firstTask.location_name,
+          location: firstTask.location,
+          description: 'Task opened from the all-work task link.',
+          actions: [{ id: 'go', title: 'Go to task' }],
+        },
+      ],
+    });
+    const caseworkerLookupResponse = [
+      {
+        email: 'all.work.caseworker@example.com',
+        firstName: 'All',
+        idamId: 'all-work-assignee-1',
+        lastName: 'Work',
+        location: {
+          id: 227101,
+          locationName: 'Taylor House',
+        },
+        roleCategory: 'LEGAL_OPERATIONS',
+        service: 'IA',
+      },
+    ];
 
     await test.step('Setup route mocks for all-work tasks', async () => {
       await setupManageTasksBaseRoutes(page, {
         taskListResponse: taskListMockResponse,
         supportedJurisdictions,
         supportedJurisdictionDetails,
+      });
+
+      await page.route(`**/data/internal/cases/${firstTask.case_id}*`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(caseMockResponse),
+        });
+      });
+
+      await page.route(`**/workallocation/case/task/${firstTask.case_id}*`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(caseTasksResponse),
+        });
+      });
+
+      await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(caseworkerLookupResponse),
+        });
       });
     });
 
@@ -34,7 +109,7 @@ test.describe(`All Work Tasks as ${userIdentifier}`, { tag: ['@integration', '@i
       await taskListPage.exuiSpinnerComponent.wait();
     });
 
-    await test.step('Verify expected all-work columns, data, and case link rendering', async () => {
+    await test.step('Verify expected all-work columns, data, and case/task link rendering', async () => {
       expect
         .soft(await taskListPage.getResultsText())
         .toBe(`Showing 1 to ${Math.min(taskListMockResponse.tasks.length, 25)} of ${taskListMockResponse.total_records} results`);
@@ -49,16 +124,55 @@ test.describe(`All Work Tasks as ${userIdentifier}`, { tag: ['@integration', '@i
       expect.soft(table[0]['Location']).toBe(taskListMockResponse.tasks[0].location_name);
       expect.soft(table[0]['Task']).toBe(taskListMockResponse.tasks[0].task_title);
 
-      const firstCase = taskListMockResponse.tasks[0];
-      const firstCaseLink = taskListPage.taskListTable.getByRole('link', { name: firstCase.case_name }).first();
+      const firstCaseLink = taskListPage.taskListTable.getByRole('link', { name: firstTask.case_name }).first();
       await expect(firstCaseLink).toBeVisible();
       await expect(firstCaseLink).toHaveAttribute(
         'href',
-        `/cases/case-details/${firstCase.jurisdiction}/${firstCase.case_type_id}/${firstCase.case_id}`
+        `/cases/case-details/${firstTask.jurisdiction}/${firstTask.case_type_id}/${firstTask.case_id}`
+      );
+
+      const firstTaskLink = taskListPage.taskListTable.getByRole('link', { name: firstTask.task_title }).first();
+      await expect(firstTaskLink).toBeVisible();
+      await expect(firstTaskLink).toHaveAttribute(
+        'href',
+        new RegExp(
+          `/cases/case-details/${firstTask.jurisdiction}/${firstTask.case_type_id}/${firstTask.case_id}(?:/tasks|#Tasks)$`
+        )
       );
     });
 
+    await test.step('Click the all-work Task link and land on the case details Tasks tab', async () => {
+      const caseDetailsResponsePromise = page.waitForResponse(
+        (response) =>
+          response.request().method() === 'GET' &&
+          response.url().includes(`/data/internal/cases/${firstTask.case_id}`) &&
+          response.status() === 200
+      );
+      const caseTasksResponsePromise = page.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST' &&
+          response.url().includes(`/workallocation/case/task/${firstTask.case_id}`) &&
+          response.status() === 200
+      );
+
+      await taskListPage.taskListTable.getByRole('link', { name: firstTask.task_title }).first().click();
+
+      await caseDetailsResponsePromise;
+      await caseTasksResponsePromise;
+
+      await expect(page).toHaveURL(
+        new RegExp(
+          `/cases/case-details/${firstTask.jurisdiction}/${firstTask.case_type_id}/${firstTask.case_id}(?:/tasks|#Tasks)(?:\\?.*)?$`
+        )
+      );
+      await expect(page.getByRole('heading', { name: 'Active tasks' })).toBeVisible();
+    });
+
     await test.step('Verify pagination controls are shown for multi-page all-work results', async () => {
+      await taskListPage.gotoAllWorkTasks();
+      await expect(taskListPage.taskListTable).toBeVisible();
+      await taskListPage.exuiSpinnerComponent.wait();
+
       await expect(taskListPage.exuiBodyComponent.paginationNextButton).toBeVisible();
       await expect(taskListPage.exuiBodyComponent.paginationPreviousButton).not.toBeVisible();
 
@@ -174,109 +288,4 @@ test.describe(`All Work Tasks as ${userIdentifier}`, { tag: ['@integration', '@i
       await expect(taskListPage.allWorkPersonSearchInput).toBeVisible();
     });
   });
-
-  test('All-work manage action matrix is rendered for each expected row', async ({ taskListPage, page }) => {
-    const taskListMockResponse = buildTaskListMock(25, '', myActionsList);
-    const allActionIds = ['assign', 'claim', 'claim-and-go', 'reassign', 'unclaim', 'go', 'cancel', 'complete'];
-
-    taskListMockResponse.tasks[0].actions = [
-      { id: 'assign', title: 'Assign task' },
-      { id: 'go', title: 'Go to task' },
-    ];
-    taskListMockResponse.tasks[1].actions = [
-      { id: 'assign', title: 'Assign task' },
-      { id: 'go', title: 'Go to task' },
-    ];
-    taskListMockResponse.tasks[3].actions = [
-      { id: 'reassign', title: 'Reassign task' },
-      { id: 'unclaim', title: 'Unassign task' },
-      { id: 'go', title: 'Go to task' },
-    ];
-
-    await test.step('Setup route mocks for all-work manage action matrix', async () => {
-      await setupManageTasksBaseRoutes(page, {
-        taskListResponse: taskListMockResponse,
-        supportedJurisdictions,
-        supportedJurisdictionDetails,
-      });
-    });
-
-    const assertManageActionsForRow = async (rowIndex: number, expectedActionIds: string[]) => {
-      await taskListPage.gotoAllWorkTasks();
-      await expect(taskListPage.taskListTable).toBeVisible();
-      await taskListPage.exuiSpinnerComponent.wait();
-      await taskListPage.openManageActionsForRow(rowIndex, `all-work manage action matrix row ${rowIndex + 1}`);
-
-      const taskActionsRow = taskListPage.getTaskActionsRow(rowIndex);
-
-      for (const actionId of allActionIds) {
-        const actionLocator = taskActionsRow.locator(`#action_${actionId}`);
-        if (expectedActionIds.includes(actionId)) {
-          await taskListPage.waitForTaskActionForRow(rowIndex, actionId, `all-work manage action matrix row ${rowIndex + 1}`);
-        } else {
-          await expect(actionLocator).toHaveCount(0);
-        }
-      }
-    };
-
-    await test.step('Validate row 1 and row 2 show Assign task and Go to task', async () => {
-      await assertManageActionsForRow(0, ['assign', 'go']);
-      await assertManageActionsForRow(1, ['assign', 'go']);
-    });
-
-    await test.step('Validate row 4 shows Reassign task, Unassign task, and Go to task', async () => {
-      await assertManageActionsForRow(3, ['reassign', 'unclaim', 'go']);
-    });
-  });
-});
-
-test.describe('All Work role-based task columns', { tag: ['@integration', '@integration-manage-tasks'] }, () => {
-  const scenarios = [
-    {
-      userIdentifier: 'IAC_CaseOfficer_R2',
-      expectedDateHeader: 'Due date',
-      notExpectedDateHeader: 'Task created',
-    },
-    {
-      userIdentifier: 'IAC_Judge_WA_R1',
-      expectedDateHeader: 'Task created',
-      notExpectedDateHeader: 'Due date',
-    },
-  ] as const;
-
-  for (const scenario of scenarios) {
-    test.describe(`All-work columns render correctly for ${scenario.userIdentifier}`, () => {
-      const taskListMockResponse = buildTaskListMock(40, '', myActionsList);
-
-      test.beforeEach(async ({ page }) => {
-        await applySessionCookies(page, scenario.userIdentifier);
-      });
-      test(`renders expected date column and not the non-expected date column`, async ({ taskListPage, page, tableUtils }) => {
-        await test.step('Setup route mocks for all-work role-based columns', async () => {
-          await setupManageTasksBaseRoutes(page, {
-            taskListResponse: taskListMockResponse,
-            supportedJurisdictions,
-            supportedJurisdictionDetails,
-          });
-        });
-
-        await test.step('Navigate to all-work tasks and parse rendered columns', async () => {
-          await taskListPage.gotoAllWorkTasks();
-          await expect(taskListPage.taskListTable).toBeVisible();
-          await taskListPage.exuiSpinnerComponent.wait();
-
-          const table = await tableUtils.parseWorkAllocationTable(taskListPage.taskListTable);
-          const headers = Object.keys(table[0] ?? {});
-
-          expect(headers).toEqual(
-            expect.arrayContaining(['Case name', 'Case category', 'Location', 'Task', 'Person', 'Priority'])
-          );
-          expect(headers).toContain(scenario.expectedDateHeader);
-          expect(headers).not.toContain(scenario.notExpectedDateHeader);
-
-          expect(table[0][scenario.expectedDateHeader]).toBeTruthy();
-        });
-      });
-    });
-  }
 });


### PR DESCRIPTION
### Jira link

See [EXUI-4536](https://tools.hmcts.net/jira/browse/EXUI-4536)

### Change description

This PR adds the All Work task-navigation parity slice on top of the shared manage-tasks Playwright foundation.

- Adds Playwright integration coverage for All Work task rows and action/navigation behaviour.
- Extends the manage-tasks mock data used by the All Work task scenarios.
- Keeps the task-navigation coverage separate from All Work cases so each PR has one behavioural focus.

Value to the test pack:

- Preserves legacy Work Allocation confidence around task-list navigation while moving the coverage into the Playwright integration layer.
- Verifies that mocked task data drives the user-facing navigation/action flow, not just isolated helper output.
- Gives reviewers and future maintainers a small, diagnosable PR for the All Work tasks area rather than another combined Work Allocation migration.

### Dependency PRs

- Depends on [EXUI-4534 shared manage-tasks Playwright foundation](https://github.com/hmcts/rpx-xui-webapp/pull/5106)

### Testing done

Automated:

- [x] `git diff --check` passed for the split branch.
- [ ] `yarn lint` not run after branch split.
- [ ] Focused Playwright integration tests not run after branch split.

Manual:

- [x] Reviewed the stacked diff against `test/EXUI-4534_shared-manage-tasks-foundation` to confirm this PR only contains the All Work task-navigation slice.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
