### PR TITLE
EXUI-4535: add All Work cases Playwright tests

### DIFF
--- a/playwright_tests_new/api/unit/all-work-cases-request-helper.unit.api.ts
+++ b/playwright_tests_new/api/unit/all-work-cases-request-helper.unit.api.ts
@@ -1,0 +1,107 @@
+import { expect, test } from '@playwright/test';
+import {
+  parseAllWorkCasesRequest,
+  waitForAllWorkCasesPageRequest,
+  waitForFilteredAllWorkCasesRequest,
+  type AllWorkCasesRequestBody,
+} from '../../integration/helpers/allWorkCasesRequest.helper.js';
+
+type FakeRequest = {
+  method: () => string;
+  postDataJSON: () => unknown;
+  url: () => string;
+};
+
+function buildRequest(overrides: Partial<FakeRequest> = {}): FakeRequest {
+  return {
+    method: () => 'POST',
+    postDataJSON: () => ({}),
+    url: () => 'https://manage-case.aat.platform.hmcts.net/workallocation/all-work/cases',
+    ...overrides,
+  };
+}
+
+async function runWaitForRequestPredicate<T>(
+  helper: (page: { waitForRequest: (predicate: (request: FakeRequest) => boolean) => Promise<FakeRequest> }) => Promise<T>,
+  requests: FakeRequest[]
+) {
+  return helper({
+    waitForRequest: async (predicate) => {
+      const matchingRequest = requests.find((request) => predicate(request));
+      if (!matchingRequest) {
+        throw new Error('No matching request');
+      }
+      return matchingRequest;
+    },
+  });
+}
+
+test.describe('all work cases request helper', { tag: '@svc-internal' }, () => {
+  test('parses the posted all-work cases request body', () => {
+    const requestBody: AllWorkCasesRequestBody = {
+      searchRequest: {
+        search_parameters: [{ key: 'actorId', values: 'abc-123' }],
+        pagination_parameters: { page_number: 2, page_size: 25 },
+      },
+      view: 'ALL_WORK_CASES',
+    };
+
+    expect(
+      parseAllWorkCasesRequest({
+        postDataJSON: () => requestBody,
+      } as never)
+    ).toEqual(requestBody);
+  });
+
+  test('waits for the filtered all-work cases request with the expected actorId', async () => {
+    const nonMatchingMethodRequest = buildRequest({ method: () => 'GET' });
+    const nonMatchingActorRequest = buildRequest({
+      postDataJSON: () => ({
+        searchRequest: {
+          search_parameters: [{ key: 'actorId', values: 'different-user' }],
+        },
+      }),
+    });
+    const matchingRequest = buildRequest({
+      postDataJSON: () => ({
+        searchRequest: {
+          search_parameters: [{ key: 'actorId', values: 'target-user' }],
+        },
+      }),
+    });
+
+    const request = await runWaitForRequestPredicate(
+      (page) => waitForFilteredAllWorkCasesRequest(page as never, 'target-user'),
+      [nonMatchingMethodRequest, nonMatchingActorRequest, matchingRequest]
+    );
+
+    expect(request).toBe(matchingRequest);
+  });
+
+  test('waits for the requested all-work cases pagination page number', async () => {
+    const nonMatchingRouteRequest = buildRequest({
+      url: () => 'https://manage-case.aat.platform.hmcts.net/workallocation/my-work/cases',
+    });
+    const nonMatchingPageRequest = buildRequest({
+      postDataJSON: () => ({
+        searchRequest: {
+          pagination_parameters: { page_number: 2, page_size: 25 },
+        },
+      }),
+    });
+    const matchingRequest = buildRequest({
+      postDataJSON: () => ({
+        searchRequest: {
+          pagination_parameters: { page_number: 3, page_size: 25 },
+        },
+      }),
+    });
+
+    const request = await runWaitForRequestPredicate(
+      (page) => waitForAllWorkCasesPageRequest(page as never, 3),
+      [nonMatchingRouteRequest, nonMatchingPageRequest, matchingRequest]
+    );
+
+    expect(request).toBe(matchingRequest);
+  });
+});

--- a/playwright_tests_new/integration/helpers/allWorkCasesRequest.helper.ts
+++ b/playwright_tests_new/integration/helpers/allWorkCasesRequest.helper.ts
@@ -1,0 +1,44 @@
+import type { Page, Request } from '@playwright/test';
+import { allWorkCasesRoutePattern } from './manageTasksMockRoutes.helper';
+
+export type AllWorkCasesSearchParameter = {
+  key?: string;
+  operator?: string;
+  values?: unknown;
+};
+
+export type AllWorkCasesRequestBody = {
+  searchRequest?: {
+    search_parameters?: AllWorkCasesSearchParameter[];
+    pagination_parameters?: { page_number?: number; page_size?: number };
+  };
+  view?: string;
+};
+
+export function parseAllWorkCasesRequest(request: Pick<Request, 'postDataJSON'>): AllWorkCasesRequestBody {
+  return request.postDataJSON() as AllWorkCasesRequestBody;
+}
+
+export async function waitForFilteredAllWorkCasesRequest(page: Page, actorId: string): Promise<Request> {
+  return page.waitForRequest((request) => {
+    if (!allWorkCasesRoutePattern.exec(request.url()) || request.method() !== 'POST') {
+      return false;
+    }
+
+    const requestBody = parseAllWorkCasesRequest(request);
+    return requestBody.searchRequest?.search_parameters?.some(
+      (parameter) => parameter.key === 'actorId' && parameter.values === actorId
+    );
+  });
+}
+
+export async function waitForAllWorkCasesPageRequest(page: Page, pageNumber: number): Promise<Request> {
+  return page.waitForRequest((request) => {
+    if (!allWorkCasesRoutePattern.exec(request.url()) || request.method() !== 'POST') {
+      return false;
+    }
+
+    const requestBody = parseAllWorkCasesRequest(request);
+    return requestBody.searchRequest?.pagination_parameters?.page_number === pageNumber;
+  });
+}

--- a/playwright_tests_new/integration/helpers/index.ts
+++ b/playwright_tests_new/integration/helpers/index.ts
@@ -14,6 +14,7 @@ export * from './searchCaseSession.helper';
 export * from './hearingsMockRoutes.helper';
 export * from './hearingJourneySetup.helper';
 export * from './ngIntegrationMockRoutes.helper';
+export * from './allWorkCasesRequest.helper';
 export * from './taskListMockRoutes.helper';
 export * from './bookingUiMockRoutes.helper';
 export * from './manageTasksMockRoutes.helper';

--- a/playwright_tests_new/integration/mocks/myCases.mock.ts
+++ b/playwright_tests_new/integration/mocks/myCases.mock.ts
@@ -21,6 +21,7 @@ export type MyCaseMock = {
   case_role: string;
   role: string;
   role_category: string;
+  assignee: string;
   hasAccess: boolean;
   actions: MyCaseActionMock[];
 };
@@ -66,7 +67,7 @@ export const myCaseDisplayValues = [...new Set(myCaseStateDefinitions.map((defin
 
 export const buildMyCaseMock = (overrides: Partial<MyCaseMock> = {}): MyCaseMock => {
   const serviceLabelByJurisdiction: Record<string, string> = {
-    IA: 'Immigration & Asylum',
+    IA: 'Immigration and Asylum',
     SSCS: 'Social security and child support',
     Other: 'Other',
   };
@@ -91,6 +92,7 @@ export const buildMyCaseMock = (overrides: Partial<MyCaseMock> = {}): MyCaseMock
     case_role: overrides.case_role ?? stateDefinition.caseRole,
     role: overrides.role ?? stateDefinition.role,
     role_category: overrides.role_category ?? stateDefinition.roleCategory,
+    assignee: overrides.assignee ?? faker.string.uuid(),
     hasAccess: overrides.hasAccess ?? true,
     actions: overrides.actions ?? [...myCasesNoActions],
   };
@@ -126,13 +128,14 @@ export const buildMyCasesMock = (uniqueCasesCount: number = 2): MyCasesResponseM
       case_type: 'Asylum',
       jurisdiction: 'IA',
       jurisdictionId: 'IA',
-      expectedServiceLabel: 'Immigration & Asylum',
+      expectedServiceLabel: 'Immigration and Asylum',
       startDate: toMiddayUtcIso('2026-01-10T00:00:00.000Z'),
       endDate: toMiddayUtcIso('2026-02-16T00:00:00.000Z'),
       next_hearing_date: toMiddayUtcIso('2026-01-20T00:00:00.000Z'),
       case_role: 'lead-judge',
       role: 'Lead Judge',
       role_category: 'JUDICIAL',
+      assignee: 'judicial-assignee-1',
       hasAccess: true,
       actions: myCasesAllocatorActions,
     }),
@@ -151,6 +154,7 @@ export const buildMyCasesMock = (uniqueCasesCount: number = 2): MyCasesResponseM
       case_role: 'case-manager',
       role: 'Case Manager',
       role_category: 'LEGAL_OPERATIONS',
+      assignee: 'legal-ops-assignee-2',
       hasAccess: true,
       actions: myCasesNoActions,
     }),

--- a/playwright_tests_new/integration/test/manageTasks/allWork/allWorkCases.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/allWork/allWorkCases.positive.spec.ts
@@ -1,0 +1,242 @@
+import { expect, test } from '../../../../E2E/fixtures';
+import {
+  allWorkCasesRoutePattern,
+  applySessionCookies,
+  parseAllWorkCasesRequest,
+  setupAllWorkCasesRoutes,
+  waitForAllWorkCasesPageRequest,
+  waitForFilteredAllWorkCasesRequest,
+} from '../../../helpers';
+import { buildMyCaseMock, type MyCaseMock } from '../../../mocks/myCases.mock';
+
+const userIdentifier = 'STAFF_ADMIN';
+
+const supportedJurisdictions = ['IA', 'SSCS'];
+const supportedJurisdictionDetails = [
+  { serviceId: 'IA', serviceName: 'Immigration and Asylum' },
+  { serviceId: 'SSCS', serviceName: 'Social security and child support' },
+];
+
+const currentFilterPerson = {
+  email: 'current.caseworker@example.com',
+  firstName: 'Current',
+  idamId: 'all-work-current-caseworker',
+  lastName: 'Allocation',
+  location: {
+    id: 231596,
+    locationName: 'Birmingham',
+    services: ['IA', 'SSCS'],
+  },
+  roleCategory: 'LEGAL_OPERATIONS',
+  service: 'IA',
+};
+
+const emptyFilterPerson = {
+  email: 'empty.caseworker@example.com',
+  firstName: 'Empty',
+  idamId: 'all-work-empty-caseworker',
+  lastName: 'Allocation',
+  location: {
+    id: 231596,
+    locationName: 'Birmingham',
+    services: ['IA', 'SSCS'],
+  },
+  roleCategory: 'LEGAL_OPERATIONS',
+  service: 'IA',
+};
+
+const allFilterPeople = [currentFilterPerson, emptyFilterPerson];
+
+const buildAllWorkCase = (index: number, overrides: Partial<MyCaseMock> = {}): MyCaseMock => {
+  const caseNumber = index + 1;
+  return buildMyCaseMock({
+    id: `all-work-allocation-${caseNumber}`,
+    case_id: `180000000000${String(caseNumber).padStart(4, '0')}`,
+    case_name: `All work case ${caseNumber}`,
+    case_category: caseNumber % 2 === 0 ? 'Protection' : 'Human rights',
+    case_type: 'Asylum',
+    jurisdiction: caseNumber % 2 === 0 ? 'SSCS' : 'IA',
+    jurisdictionId: caseNumber % 2 === 0 ? 'SSCS' : 'IA',
+    expectedServiceLabel: caseNumber % 2 === 0 ? 'Social security and child support' : 'Immigration and Asylum',
+    case_role: 'case-manager',
+    role: 'Case Manager',
+    role_category: 'LEGAL_OPERATIONS',
+    assignee: currentFilterPerson.idamId,
+    actions: [],
+    ...overrides,
+  });
+};
+
+const pagedAllWorkCases = Array.from({ length: 140 }, (_, index) => buildAllWorkCase(index));
+
+test.beforeEach(async ({ page }) => {
+  await applySessionCookies(page, userIdentifier);
+});
+
+test.describe(`All Work cases as ${userIdentifier}`, { tag: ['@integration', '@integration-manage-tasks'] }, () => {
+  test('shows the pre-filter prompt and empty-state message when no cases match the selected person', async ({
+    taskListPage,
+    page,
+  }) => {
+    await test.step('Setup all-work cases routes with an empty result for the empty filter user', async () => {
+      await setupAllWorkCasesRoutes(
+        page,
+        { cases: [], total_records: 0, unique_cases: 0 },
+        {
+          supportedJurisdictions,
+          supportedJurisdictionDetails,
+          routeHandler: async (route) => {
+            const requestBody = parseAllWorkCasesRequest(route.request());
+            const actorId = requestBody.searchRequest?.search_parameters?.find(
+              (parameter) => parameter.key === 'actorId'
+            )?.values;
+
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                cases: actorId === emptyFilterPerson.idamId ? [] : pagedAllWorkCases.slice(0, 25),
+                total_records: actorId === emptyFilterPerson.idamId ? 0 : pagedAllWorkCases.length,
+                unique_cases: actorId === emptyFilterPerson.idamId ? 0 : pagedAllWorkCases.length,
+              }),
+            });
+          },
+        }
+      );
+
+      await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(allFilterPeople),
+        });
+      });
+    });
+
+    await test.step('Open All work cases and verify the prompt is shown before any filter is applied', async () => {
+      await taskListPage.gotoAllWorkCases();
+      await expect(taskListPage.allWorkCasesApplyPrompt).toBeVisible();
+      await expect(taskListPage.taskRows).toHaveCount(0);
+    });
+
+    await test.step('Apply the empty-result person filter and verify the empty-state message', async () => {
+      const allWorkCasesRequest = page.waitForRequest((request) => {
+        if (!allWorkCasesRoutePattern.exec(request.url()) || request.method() !== 'POST') {
+          return false;
+        }
+
+        const requestBody = parseAllWorkCasesRequest(request);
+        return requestBody.searchRequest?.search_parameters?.some(
+          (parameter) => parameter.key === 'actorId' && parameter.values === emptyFilterPerson.idamId
+        );
+      });
+
+      await taskListPage.applyAllWorkCasesPersonFilter('Empty', 'Empty Allocation');
+      await allWorkCasesRequest;
+
+      await expect(taskListPage.allWorkCasesEmptyMessage).toBeVisible();
+      await expect(taskListPage.paginationControls).toHaveCount(0);
+      await expect(taskListPage.taskRows).toHaveCount(0);
+    });
+  });
+
+  test('renders filtered all-work cases, captures the request payload, and paginates backend-backed results', async ({
+    taskListPage,
+    page,
+  }) => {
+    await test.step('Setup all-work cases routes with backend-style pagination and caseworker search', async () => {
+      await setupAllWorkCasesRoutes(
+        page,
+        { cases: [], total_records: 0, unique_cases: 0 },
+        {
+          supportedJurisdictions,
+          supportedJurisdictionDetails,
+          routeHandler: async (route) => {
+            const requestBody = parseAllWorkCasesRequest(route.request());
+            const pageNumber = requestBody.searchRequest?.pagination_parameters?.page_number ?? 1;
+            const pageSize = requestBody.searchRequest?.pagination_parameters?.page_size ?? 25;
+            const actorId = requestBody.searchRequest?.search_parameters?.find(
+              (parameter) => parameter.key === 'actorId'
+            )?.values;
+            const resultSet = actorId === currentFilterPerson.idamId ? pagedAllWorkCases : [];
+            const startIndex = (pageNumber - 1) * pageSize;
+
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                cases: resultSet.slice(startIndex, startIndex + pageSize),
+                total_records: resultSet.length,
+                unique_cases: resultSet.length,
+              }),
+            });
+          },
+        }
+      );
+
+      await page.route('**/workallocation/caseworker/getUsersByServiceName*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(allFilterPeople),
+        });
+      });
+    });
+
+    await test.step('Apply the current-caseworker filter and verify the initial search payload', async () => {
+      await taskListPage.gotoAllWorkCases();
+      await expect(taskListPage.allWorkCasesApplyPrompt).toBeVisible();
+
+      const firstRequestPromise = waitForFilteredAllWorkCasesRequest(page, currentFilterPerson.idamId);
+
+      await taskListPage.applyAllWorkCasesPersonFilter('Current', 'Current Allocation');
+      const firstRequest = await firstRequestPromise;
+      const requestBody = parseAllWorkCasesRequest(firstRequest);
+
+      expect(requestBody.view).toBe('AllWorkCases');
+      expect(requestBody.searchRequest?.pagination_parameters).toEqual({ page_number: 1, page_size: 25 });
+      expect(requestBody.searchRequest?.search_parameters).toEqual(
+        expect.arrayContaining([
+          { key: 'jurisdiction', operator: 'EQUAL', values: 'IA' },
+          { key: 'location_id', operator: 'EQUAL', values: '' },
+          { key: 'actorId', operator: 'EQUAL', values: currentFilterPerson.idamId },
+          { key: 'role', operator: 'EQUAL', values: 'Legal Ops' },
+        ])
+      );
+    });
+
+    await test.step('Verify the table data, case link, non-sortable headers, and page 1 summary', async () => {
+      const firstCase = pagedAllWorkCases[0];
+
+      await expect(taskListPage.taskListTable).toBeVisible();
+      await expect(taskListPage.taskRows).toHaveCount(25);
+      await expect(taskListPage.allWorkCasesApplyPrompt).toHaveCount(0);
+      await expect(taskListPage.paginationControls).toBeVisible();
+      await expect(taskListPage.paginationCurrentPage).toContainText('1');
+      expect(await taskListPage.getPaginationSummaryText()).toBe('Showing 1 to 25 of 140 results');
+
+      const firstCaseLink = taskListPage.taskListTable.getByRole('link', { name: firstCase.case_name }).first();
+      await expect(firstCaseLink).toHaveAttribute(
+        'href',
+        `/cases/case-details/${firstCase.jurisdictionId}/${firstCase.case_type}/${firstCase.case_id}`
+      );
+
+      await expect(taskListPage.sortByCaseNameTableHeader).toHaveCount(0);
+      await expect(taskListPage.sortByCaseCategoryTableHeader).toHaveCount(0);
+    });
+
+    await test.step('Move to page 3 and verify the backend pagination request and summary', async () => {
+      const thirdPageRequestPromise = waitForAllWorkCasesPageRequest(page, 3);
+
+      await taskListPage.openPaginationPage(3);
+      const thirdPageRequest = await thirdPageRequestPromise;
+
+      expect(parseAllWorkCasesRequest(thirdPageRequest).searchRequest?.pagination_parameters).toEqual({
+        page_number: 3,
+        page_size: 25,
+      });
+      await expect(taskListPage.paginationCurrentPage).toContainText('3');
+      expect(await taskListPage.getPaginationSummaryText()).toBe('Showing 51 to 75 of 140 results');
+    });
+  });
+});


### PR DESCRIPTION
### Jira link

See [EXUI-4535](https://tools.hmcts.net/jira/browse/EXUI-4535)

### Change description

This PR adds the All Work cases parity slice on top of the shared manage-tasks Playwright foundation.

- Adds Playwright integration coverage for All Work cases behaviour.
- Adds reusable request-helper support for the All Work cases filters and pagination contract.
- Adds direct API/unit coverage for the request-helper logic so filter/query construction is validated outside the browser.
- Extends the manage-tasks mock data needed for realistic All Work case-list scenarios.

Value to the test pack:

- Moves an important part of the legacy Work Allocation coverage into Playwright integration tests, keeping the behaviour closer to the Angular route and component flow that users exercise.
- Covers case-list filtering/paging style behaviour in a deterministic mocked integration layer, which gives faster and more reliable feedback than full E2E for this parity area.
- Keeps All Work cases separate from task-navigation and My Work/My Cases slices, making failures easier to diagnose and review.

### Dependency PRs

- Depends on [EXUI-4534 shared manage-tasks Playwright foundation](https://github.com/hmcts/rpx-xui-webapp/pull/5106)

### Testing done

Automated:

- [x] `git diff --check` passed for the split branch.
- [ ] `yarn lint` not run after branch split.
- [ ] Focused Playwright integration tests not run after branch split.

Manual:

- [x] Reviewed the stacked diff against `test/EXUI-4534_shared-manage-tasks-foundation` to confirm this PR only contains the All Work cases slice.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
