### PR TITLE
EXUI-4537: add My Cases pagination Playwright tests

### DIFF
--- a/playwright_tests_new/integration/mocks/myCases.mock.ts
+++ b/playwright_tests_new/integration/mocks/myCases.mock.ts
@@ -21,6 +21,7 @@ export type MyCaseMock = {
   case_role: string;
   role: string;
   role_category: string;
+  assignee: string;
   hasAccess: boolean;
   actions: MyCaseActionMock[];
 };
@@ -66,7 +67,7 @@ export const myCaseDisplayValues = [...new Set(myCaseStateDefinitions.map((defin
 
 export const buildMyCaseMock = (overrides: Partial<MyCaseMock> = {}): MyCaseMock => {
   const serviceLabelByJurisdiction: Record<string, string> = {
-    IA: 'Immigration & Asylum',
+    IA: 'Immigration and Asylum',
     SSCS: 'Social security and child support',
     Other: 'Other',
   };
@@ -91,6 +92,7 @@ export const buildMyCaseMock = (overrides: Partial<MyCaseMock> = {}): MyCaseMock
     case_role: overrides.case_role ?? stateDefinition.caseRole,
     role: overrides.role ?? stateDefinition.role,
     role_category: overrides.role_category ?? stateDefinition.roleCategory,
+    assignee: overrides.assignee ?? faker.string.uuid(),
     hasAccess: overrides.hasAccess ?? true,
     actions: overrides.actions ?? [...myCasesNoActions],
   };
@@ -126,13 +128,14 @@ export const buildMyCasesMock = (uniqueCasesCount: number = 2): MyCasesResponseM
       case_type: 'Asylum',
       jurisdiction: 'IA',
       jurisdictionId: 'IA',
-      expectedServiceLabel: 'Immigration & Asylum',
+      expectedServiceLabel: 'Immigration and Asylum',
       startDate: toMiddayUtcIso('2026-01-10T00:00:00.000Z'),
       endDate: toMiddayUtcIso('2026-02-16T00:00:00.000Z'),
       next_hearing_date: toMiddayUtcIso('2026-01-20T00:00:00.000Z'),
       case_role: 'lead-judge',
       role: 'Lead Judge',
       role_category: 'JUDICIAL',
+      assignee: 'judicial-assignee-1',
       hasAccess: true,
       actions: myCasesAllocatorActions,
     }),
@@ -151,6 +154,7 @@ export const buildMyCasesMock = (uniqueCasesCount: number = 2): MyCasesResponseM
       case_role: 'case-manager',
       role: 'Case Manager',
       role_category: 'LEGAL_OPERATIONS',
+      assignee: 'legal-ops-assignee-2',
       hasAccess: true,
       actions: myCasesNoActions,
     }),

--- a/playwright_tests_new/integration/test/manageTasks/myCases/myCases.pagination.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/myCases/myCases.pagination.positive.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '../../../../E2E/fixtures';
+import { applySessionCookies, setupMyCasesRoutes } from '../../../helpers';
+import { buildMyCaseMock, buildMyCases } from '../../../mocks/myCases.mock';
+
+const userIdentifier = 'STAFF_ADMIN';
+
+test.beforeEach(async ({ page }) => {
+  await applySessionCookies(page, userIdentifier);
+});
+
+test.describe(`My Cases pagination as ${userIdentifier}`, { tag: ['@integration', '@integration-manage-tasks'] }, () => {
+  test('keeps large My cases result sets unpaginated and renders non-sortable columns as plain headers', async ({
+    taskListPage,
+    page,
+  }) => {
+    const myCasesResponse = buildMyCases(
+      140,
+      (index) => {
+        const caseNumber = index + 1;
+        const jurisdictionId = index % 2 === 0 ? 'IA' : 'SSCS';
+        return buildMyCaseMock({
+          id: `allocation-${caseNumber}`,
+          case_id: `160000000000${String(caseNumber).padStart(4, '0')}`,
+          case_name: `Managed case ${caseNumber}`,
+          case_category: caseNumber % 2 === 0 ? 'Protection' : 'Human rights',
+          case_type: 'Asylum',
+          jurisdiction: jurisdictionId,
+          jurisdictionId,
+          expectedServiceLabel: jurisdictionId === 'IA' ? 'Immigration and Asylum' : 'Social security and child support',
+        });
+      },
+      100
+    );
+
+    await test.step('Setup route mocks for a multi-page My cases response', async () => {
+      await setupMyCasesRoutes(page, myCasesResponse);
+    });
+
+    await test.step('Open My cases and verify the large-result summary stays unpaginated', async () => {
+      await taskListPage.gotoMyCases();
+      await expect(taskListPage.taskListTable).toBeVisible();
+      await taskListPage.exuiSpinnerComponent.wait();
+
+      await expect(taskListPage.paginationControls).toHaveCount(0);
+      await expect(taskListPage.uniqueCasesSummary).toContainText('100 cases');
+      await expect(taskListPage.taskRows).toHaveCount(140);
+      expect(await taskListPage.getPaginationSummaryText()).toBe('Showing 140 results');
+    });
+
+    await test.step('Verify case name and case category remain non-sortable', async () => {
+      await expect(taskListPage.sortByCaseNameTableHeader).toHaveCount(0);
+      await expect(taskListPage.sortByCaseCategoryTableHeader).toHaveCount(0);
+    });
+
+    await test.step('Verify the final row is still rendered in the same unpaginated table', async () => {
+      await expect(taskListPage.taskListTable.getByRole('link', { name: 'Managed case 140' })).toBeVisible();
+    });
+  });
+
+  test('hides pagination controls when all results fit on one page', async ({ taskListPage, page }) => {
+    const myCasesResponse = buildMyCases(20, (index) =>
+      buildMyCaseMock({
+        id: `single-page-allocation-${index + 1}`,
+        case_id: `170000000000${String(index + 1).padStart(4, '0')}`,
+        case_name: `Single page case ${index + 1}`,
+      })
+    );
+
+    await test.step('Setup route mocks for a single-page My cases response', async () => {
+      await setupMyCasesRoutes(page, myCasesResponse);
+    });
+
+    await test.step('Open My cases and verify pagination controls are hidden', async () => {
+      await taskListPage.gotoMyCases();
+      await expect(taskListPage.taskListTable).toBeVisible();
+      await taskListPage.exuiSpinnerComponent.wait();
+
+      await expect(taskListPage.paginationControls).toHaveCount(0);
+      await expect(taskListPage.uniqueCasesSummary).toContainText('20 cases');
+      expect(await taskListPage.getPaginationSummaryText()).toMatch(/Showing (?:1 to 20 of 20|20) results/);
+    });
+  });
+});


### PR DESCRIPTION
### Jira link

See [EXUI-4537](https://tools.hmcts.net/jira/browse/EXUI-4537)

### Change description

This PR adds the My Cases pagination parity slice on top of the shared manage-tasks Playwright foundation.

- Adds Playwright integration coverage for My Cases pagination behaviour.
- Extends the My Cases mock data to support deterministic multi-page scenarios.
- Keeps pagination coverage isolated from All Work and My Work filters so the parity gap is reviewed and maintained as a focused slice.

Value to the test pack:

- Covers a user-visible Work Allocation behaviour that is easy to regress when list state, page offsets, or mock response contracts change.
- Provides deterministic Playwright integration feedback for pagination without depending on live case volumes.
- Helps retire the matching legacy Work Allocation coverage with a clearer one-to-one behavioural replacement.

### Dependency PRs

- Depends on [EXUI-4534 shared manage-tasks Playwright foundation](https://github.com/hmcts/rpx-xui-webapp/pull/5106)

### Testing done

Automated:

- [x] `git diff --check` passed for the split branch.
- [ ] `yarn lint` not run after branch split.
- [ ] Focused Playwright integration tests not run after branch split.

Manual:

- [x] Reviewed the stacked diff against `test/EXUI-4534_shared-manage-tasks-foundation` to confirm this PR only contains the My Cases pagination slice.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
