### PR TITLE
test: prewarm case file view integration sessions

### DIFF
--- a/playwright_tests_new/api/unit/search-case-session.unit.api.ts
+++ b/playwright_tests_new/api/unit/search-case-session.unit.api.ts
@@ -29,6 +29,8 @@ test.describe('search case session helper', { tag: '@svc-internal' }, () => {
       'FPL_GLOBAL_SEARCH',
       'SOLICITOR',
       'STAFF_ADMIN',
+      'RESTRICTED_CASE_FILE_VIEW_ON',
+      'RESTRICTED_CASE_FILE_VIEW_OFF',
       'SEARCH_EMPLOYMENT_CASE',
     ]);
   });

--- a/playwright_tests_new/integration/helpers/searchCaseSession.helper.ts
+++ b/playwright_tests_new/integration/helpers/searchCaseSession.helper.ts
@@ -2,7 +2,13 @@ import type { Page, TestInfo } from '@playwright/test';
 import { applySessionCookies, loadSessionCookies } from '../../common/sessionCapture';
 
 const defaultSearchCaseSessionUsers = ['FPL_GLOBAL_SEARCH'] as const;
-const defaultIntegrationWarmupUsers = ['FPL_GLOBAL_SEARCH', 'SOLICITOR', 'STAFF_ADMIN'] as const;
+const defaultIntegrationWarmupUsers = [
+  'FPL_GLOBAL_SEARCH',
+  'SOLICITOR',
+  'STAFF_ADMIN',
+  'RESTRICTED_CASE_FILE_VIEW_ON',
+  'RESTRICTED_CASE_FILE_VIEW_OFF',
+] as const;
 
 function parseUserList(rawValue?: string): string[] {
   return Array.from(

--- a/playwright_tests_new/integration/test/manageTasks/caseTaskList/caseTaskList.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/caseTaskList/caseTaskList.positive.spec.ts
@@ -7,8 +7,14 @@ import { buildAsylumCaseMock } from '../../../mocks/cases/asylumCase.mock';
 
 const userIdentifier = 'STAFF_ADMIN';
 const inSixHours = faker.date.soon({ days: 0.25 }).toISOString();
-const inTwoDays = faker.date.soon({ days: 2 }).toISOString();
-const in90Days = faker.date.future().toISOString();
+const futureDateAtNoonUtc = (daysFromNow: number): string => {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + daysFromNow);
+  date.setUTCHours(12, 0, 0, 0);
+  return date.toISOString();
+};
+const inTwoDays = futureDateAtNoonUtc(2);
+const in90Days = futureDateAtNoonUtc(90);
 const caseId = faker.number.int({ min: 1000000000, max: 9999999999 }).toString();
 let assigneeId: string | null = null;
 const caseMockResponse = buildAsylumCaseMock({ caseId });


### PR DESCRIPTION
## What changed

- Added the case file view ON/OFF users to the default Playwright integration session warm-up pool.
- Updated the direct session warm-up unit test expectation.

## Why

The master integration report showed case file view failures caused by cold-start session lock contention. The affected tests passed on retry once the session existed, so this fix prewarms those sessions before parallel workers start instead of increasing timeouts or changing the session lock implementation.

## Evidence

- `PLAYWRIGHT_SKIP_INSTALL=true yarn playwright test --project=node-api playwright_tests_new/api/unit/search-case-session.unit.api.ts`
  - `4 passed`
- `PLAYWRIGHT_SKIP_INSTALL=true yarn test:playwright:integration playwright_tests_new/integration/test/caseFileView/caseFileView.positive.spec.ts playwright_tests_new/integration/test/caseFileView/caseFileView.negative.spec.ts`
  - `6 passed`
- `yarn lint`
  - passed with existing repo warnings, `0 errors`

## Jira

[EXUI-4550](https://tools.hmcts.net/jira/browse/EXUI-4550)