### PR TITLE
EXUI-4587: fix Fortify config password findings

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -42,6 +42,40 @@ def vault     = "rpx"
 def channel   = '#xui-pipeline'
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
+// When failFast interrupts other branches, Jenkins may surface either:
+// - FlowInterruptedException with a FailFastCause, or
+// - AbortException from a terminated `sh` (e.g. exit 143).
+// Normalize those to ABORTED so truly failing branches stay FAILED.
+def handleFailFastAbort = { Exception e ->
+    def abortedByFailFast = false
+    def failFastExitCodes = ['129', '137', '143']
+    if (e instanceof org.jenkinsci.plugins.workflow.steps.FlowInterruptedException) {
+        try {
+            def fie = (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException) e
+            def causes = (fie.getCauses() ?: []).collect { c -> c?.getClass()?.getName() }.findAll { it }
+            abortedByFailFast = causes.any { it?.endsWith('FailFastCause') }
+            echo "[failFast] FlowInterruptedException: causes=${causes}"
+        } catch (ignored) {
+            echo "[failFast] FlowInterruptedException: causes=<unavailable>"
+        }
+    } else if (e instanceof hudson.AbortException) {
+        def msg = e.getMessage() ?: ''
+        def matcher = (msg =~ /(exit code|status)\s+(\d+)/)
+        def exitCode = matcher.find() ? matcher.group(2) : null
+        abortedByFailFast = (currentBuild?.result == 'ABORTED') || (exitCode in failFastExitCodes)
+        echo "[failFast] AbortException: buildResult=${currentBuild?.result}, exitCode=${exitCode}"
+    } else {
+        echo "[failFast] Non-abort exception: ${e.getClass().getName()}: ${e.getMessage()}"
+    }
+    if (abortedByFailFast) {
+        echo "[failFast] Marking stage as ABORTED due to failFast interruption"
+        catchError(buildResult: 'ABORTED', stageResult: 'ABORTED') { throw e }
+        return true
+    }
+    echo "[failFast] Not a failFast interruption; rethrowing"
+    return false
+}
+
 def archivePlaywrightDiagnostics = {
     steps.sh '''
         set +e
@@ -405,31 +439,6 @@ withNightlyPipeline(type, product, component) {
     afterSuccess('fortify-scan') {
       try {
       recordPlaywrightLoadEvent('Nightly functional tests', 'start')
-      stage('API Tests') {
-        try {
-          recordPlaywrightLoadEvent('API', 'start')
-          withEnv([
-            'ORG_USER_ASSIGNMENT_MODE=external',
-            'ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal',
-            'FUNCTIONAL_TESTS_WORKERS=4',
-            "PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES=${params.PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES ? 'true' : 'false'}"
-          ]) {
-            yarnBuilder.yarn('test:api:pw:coverage:raw')
-          }
-        } finally {
-          recordPlaywrightLoadEvent('API', 'finish')
-          publishHTML([
-            allowMissing         : true,
-            alwaysLinkToLastBuild: true,
-            keepAll              : true,
-            reportDir            : 'functional-output/tests/api_functional/odhin-report/',
-            reportFiles          : 'xui-playwright-api.html',
-            reportName           : 'API Functional Test'
-          ])
-          archivePlaywrightDiagnostics()
-        }
-      }
-      
         stage('Playwright Install All Browsers') {
             try {
               recordPlaywrightLoadEvent('Playwright browser install', 'start')
@@ -441,48 +450,91 @@ withNightlyPipeline(type, product, component) {
             }
         }
 
-        stage('Playwright Integration Tests') {
-                try {
-                    recordPlaywrightLoadEvent('Integration', 'start')
-                    runPlaywrightIntegrationProfileMatrix()
-                } finally {
-                    recordPlaywrightLoadEvent('Integration', 'finish')
-                    echo '[playwright-integration] Integration reports published via HTML Publisher'
-                    archivePlaywrightDiagnostics()
+        stage('Nightly Functional Tests (Parallel)') {
+            parallel(
+                failFast: true,
+                api: {
+                    stage('API Tests') {
+                        try {
+                            recordPlaywrightLoadEvent('API', 'start')
+                            withEnv([
+                                'ORG_USER_ASSIGNMENT_MODE=external',
+                                'ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal',
+                                'FUNCTIONAL_TESTS_WORKERS=4',
+                                "PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES=${params.PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES ? 'true' : 'false'}"
+                            ]) {
+                                yarnBuilder.yarn('test:api:pw:coverage:raw')
+                            }
+                        } catch (Exception e) {
+                            echo "[failFast] API Tests catch: ${e.getClass().getName()}: ${e.getMessage()}"
+                            if (handleFailFastAbort(e)) { return }
+                            throw e
+                        } finally {
+                            recordPlaywrightLoadEvent('API', 'finish')
+                            publishHTML([
+                                allowMissing         : true,
+                                alwaysLinkToLastBuild: true,
+                                keepAll              : true,
+                                reportDir            : 'functional-output/tests/api_functional/odhin-report/',
+                                reportFiles          : 'xui-playwright-api.html',
+                                reportName           : 'Nightly API Functional Test'
+                            ])
+                        }
+                    }
+                },
+                playwrightIntegration: {
+                    stage('Playwright Integration Tests') {
+                        try {
+                            recordPlaywrightLoadEvent('Integration', 'start')
+                            runPlaywrightIntegrationProfileMatrix()
+                        } catch (Exception e) {
+                            echo "[failFast] Playwright Integration Tests catch: ${e.getClass().getName()}: ${e.getMessage()}"
+                            if (handleFailFastAbort(e)) { return }
+                            throw e
+                        } finally {
+                            recordPlaywrightLoadEvent('Integration', 'finish')
+                            echo '[playwright-integration] Integration reports published via HTML Publisher'
+                        }
+                    }
+                },
+                playwrightE2E: {
+                    stage('Cross Browser Test') {
+                        try {
+                            recordPlaywrightLoadEvent('E2E', 'start')
+                            withEnv([
+                                'ORG_USER_ASSIGNMENT_MODE=external',
+                                'ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal',
+                                'FUNCTIONAL_TESTS_WORKERS=2',
+                                'E2E_PW_INCLUDE_TAGS=@nightly',
+                                'E2E_PW_EXCLUDED_TAGS_OVERRIDE=@none',
+                                'PW_SESSION_CAPTURE_FAILURE_TTL_MS=0',
+                                'PLAYWRIGHT_SKIP_INSTALL=true',
+                                "PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES=${params.PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES ? 'true' : 'false'}"
+                            ]) {
+                                yarnBuilder.yarn('test:crossbrowser:raw')
+                            }
+                        } catch (Exception e) {
+                            echo "[failFast] Playwright E2E catch: ${e.getClass().getName()}: ${e.getMessage()}"
+                            if (handleFailFastAbort(e)) { return }
+                            throw e
+                        } finally {
+                            recordPlaywrightLoadEvent('E2E', 'finish')
+                            publishHTML([
+                                allowMissing         : true,
+                                alwaysLinkToLastBuild: true,
+                                keepAll              : true,
+                                reportDir            : "functional-output/tests/playwright-e2e/odhin-report/",
+                                reportFiles          : 'xui-playwright-e2e.html',
+                                reportName           : 'Nightly Playwright Cross Browser Tests'
+                            ])
+                        }
+                    }
                 }
-        }
-
-      stage('Cross Browser Test') {
-            try {
-              recordPlaywrightLoadEvent('E2E', 'start')
-              withEnv([
-                'ORG_USER_ASSIGNMENT_MODE=external',
-                'ORG_USER_ASSIGNMENT_MODE_ORDER=external,internal',
-                'FUNCTIONAL_TESTS_WORKERS=2',
-                'E2E_PW_INCLUDE_TAGS=@nightly',
-                'E2E_PW_EXCLUDED_TAGS_OVERRIDE=@none',
-                'PW_SESSION_CAPTURE_FAILURE_TTL_MS=0',
-                "PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES=${params.PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES ? 'true' : 'false'}"
-              ]) {
-                yarnBuilder.yarn('test:crossbrowser:raw')
-              }
-            } catch (Error) {
-              unstable(message: "${STAGE_NAME} is unstable: " + Error.toString())
-            } finally {
-              recordPlaywrightLoadEvent('E2E', 'finish')
-              publishHTML([
-              allowMissing         : true,
-              alwaysLinkToLastBuild: true,
-              keepAll              : true,
-              reportDir            : "functional-output/tests/playwright-e2e/odhin-report/",
-              reportFiles          : 'xui-playwright-e2e.html',
-              reportName           : 'XUI Manage Cases Playwright Cross Browser Tests'
-              ])
-              archivePlaywrightDiagnostics()
-            }
+            )
         }
       } finally {
         recordPlaywrightLoadEvent('Nightly functional tests', 'finish')
+        archivePlaywrightDiagnostics()
       }
 
         // yarnBuilder.yarn('test:a11y')

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -498,7 +498,7 @@ withNightlyPipeline(type, product, component) {
                     }
                 },
                 playwrightE2E: {
-                    stage('Playwright E2E') {
+                    stage('Playwright E2E Cross Browser') {
                         try {
                             recordPlaywrightLoadEvent('E2E', 'start')
                             withEnv([
@@ -511,7 +511,7 @@ withNightlyPipeline(type, product, component) {
                                 'PLAYWRIGHT_SKIP_INSTALL=true',
                                 "PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES=${params.PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES ? 'true' : 'false'}"
                             ]) {
-                                yarnBuilder.yarn('test:playwrightE2E:raw')
+                                yarnBuilder.yarn('test:crossbrowser:raw')
                             }
                         } catch (Exception e) {
                             echo "[failFast] Playwright E2E catch: ${e.getClass().getName()}: ${e.getMessage()}"
@@ -525,7 +525,7 @@ withNightlyPipeline(type, product, component) {
                                 keepAll              : true,
                                 reportDir            : "functional-output/tests/playwright-e2e/odhin-report/",
                                 reportFiles          : 'xui-playwright-e2e.html',
-                                reportName           : 'Nightly Playwright E2E'
+                                reportName           : 'Nightly Playwright E2E Cross Browser'
                             ])
                         }
                     }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -498,7 +498,7 @@ withNightlyPipeline(type, product, component) {
                     }
                 },
                 playwrightE2E: {
-                    stage('Cross Browser Test') {
+                    stage('Playwright E2E') {
                         try {
                             recordPlaywrightLoadEvent('E2E', 'start')
                             withEnv([
@@ -511,7 +511,7 @@ withNightlyPipeline(type, product, component) {
                                 'PLAYWRIGHT_SKIP_INSTALL=true',
                                 "PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES=${params.PLAYWRIGHT_IGNORE_GLOBAL_EXCLUDES ? 'true' : 'false'}"
                             ]) {
-                                yarnBuilder.yarn('test:crossbrowser:raw')
+                                yarnBuilder.yarn('test:playwrightE2E:raw')
                             }
                         } catch (Exception e) {
                             echo "[failFast] Playwright E2E catch: ${e.getClass().getName()}: ${e.getMessage()}"
@@ -525,7 +525,7 @@ withNightlyPipeline(type, product, component) {
                                 keepAll              : true,
                                 reportDir            : "functional-output/tests/playwright-e2e/odhin-report/",
                                 reportFiles          : 'xui-playwright-e2e.html',
-                                reportName           : 'Nightly Playwright Cross Browser Tests'
+                                reportName           : 'Nightly Playwright E2E'
                             ])
                         }
                     }

--- a/api/configuration/index.spec.ts
+++ b/api/configuration/index.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import 'mocha';
+import * as sinon from 'sinon';
+import * as config from 'config';
+import { getConfigValue } from './index';
+
+describe('configuration', () => {
+  let sandbox: sinon.SinonSandbox;
+  let originalSystemUserPassword: string | undefined;
+  let originalPactBrokerPassword: string | undefined;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    originalSystemUserPassword = process.env.SYSTEM_USER_PASSWORD;
+    originalPactBrokerPassword = process.env.PACT_BROKER_PASSWORD;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+
+    if (originalSystemUserPassword === undefined) {
+      delete process.env.SYSTEM_USER_PASSWORD;
+    } else {
+      process.env.SYSTEM_USER_PASSWORD = originalSystemUserPassword;
+    }
+
+    if (originalPactBrokerPassword === undefined) {
+      delete process.env.PACT_BROKER_PASSWORD;
+    } else {
+      process.env.PACT_BROKER_PASSWORD = originalPactBrokerPassword;
+    }
+  });
+
+  it('should read the system user password directly from the environment when set', () => {
+    process.env.SYSTEM_USER_PASSWORD = 'system-user-password-from-env';
+    const configGetStub = sandbox.stub(config, 'get').returns('system-user-password-from-config');
+
+    const value = getConfigValue('secrets.rpx.system-user-password');
+
+    expect(value).to.equal('system-user-password-from-env');
+    expect(configGetStub).not.to.have.been.called;
+  });
+
+  it('should read the Pact broker password directly from the environment when set', () => {
+    process.env.PACT_BROKER_PASSWORD = 'pact-broker-password-from-env';
+    const configGetStub = sandbox.stub(config, 'get').returns('pact-broker-password-from-config');
+
+    const value = getConfigValue('pact.brokerPassword');
+
+    expect(value).to.equal('pact-broker-password-from-env');
+    expect(configGetStub).not.to.have.been.called;
+  });
+
+  it('should fall back to config for env-only password references when the environment is not set', () => {
+    delete process.env.SYSTEM_USER_PASSWORD;
+    const configGetStub = sandbox.stub(config, 'get').returns('system-user-password-from-config');
+
+    const value = getConfigValue('secrets.rpx.system-user-password');
+
+    expect(value).to.equal('system-user-password-from-config');
+    expect(configGetStub).to.have.been.calledOnceWith('secrets.rpx.system-user-password');
+  });
+
+  it('should continue to read normal references from config', () => {
+    process.env.SYSTEM_USER_PASSWORD = 'system-user-password-from-env';
+    const configGetStub = sandbox.stub(config, 'get').returns('https://idam.example.test');
+
+    const value = getConfigValue('services.idam.idamApiUrl');
+
+    expect(value).to.equal('https://idam.example.test');
+    expect(configGetStub).to.have.been.calledOnceWith('services.idam.idamApiUrl');
+  });
+});

--- a/api/configuration/index.spec.ts
+++ b/api/configuration/index.spec.ts
@@ -38,7 +38,7 @@ describe('configuration', () => {
     const value = getConfigValue('secrets.rpx.system-user-password');
 
     expect(value).to.equal('system-user-password-from-env');
-    expect(configGetStub).not.to.have.been.called;
+    sinon.assert.notCalled(configGetStub);
   });
 
   it('should read the Pact broker password directly from the environment when set', () => {
@@ -48,7 +48,7 @@ describe('configuration', () => {
     const value = getConfigValue('pact.brokerPassword');
 
     expect(value).to.equal('pact-broker-password-from-env');
-    expect(configGetStub).not.to.have.been.called;
+    sinon.assert.notCalled(configGetStub);
   });
 
   it('should fall back to config for env-only password references when the environment is not set', () => {
@@ -58,7 +58,7 @@ describe('configuration', () => {
     const value = getConfigValue('secrets.rpx.system-user-password');
 
     expect(value).to.equal('system-user-password-from-config');
-    expect(configGetStub).to.have.been.calledOnceWith('secrets.rpx.system-user-password');
+    sinon.assert.calledOnceWithExactly(configGetStub, 'secrets.rpx.system-user-password');
   });
 
   it('should continue to read normal references from config', () => {
@@ -68,6 +68,6 @@ describe('configuration', () => {
     const value = getConfigValue('services.idam.idamApiUrl');
 
     expect(value).to.equal('https://idam.example.test');
-    expect(configGetStub).to.have.been.calledOnceWith('services.idam.idamApiUrl');
+    sinon.assert.calledOnceWithExactly(configGetStub, 'services.idam.idamApiUrl');
   });
 });

--- a/api/configuration/index.ts
+++ b/api/configuration/index.ts
@@ -17,7 +17,20 @@ propertiesVolume.addTo(config);
  * @see references.ts
  * @param reference - ie. 'services.ccdDefApi'
  */
-export const getConfigValue = <T = string>(reference: string): T => config.get<T>(reference);
+const ENV_ONLY_CONFIG_REFERENCES: Record<string, string> = {
+  'pact.brokerPassword': 'PACT_BROKER_PASSWORD',
+  'secrets.rpx.system-user-password': 'SYSTEM_USER_PASSWORD',
+};
+
+export const getConfigValue = <T = string>(reference: string): T => {
+  const envName = ENV_ONLY_CONFIG_REFERENCES[reference];
+
+  if (envName && process.env[envName]) {
+    return process.env[envName] as T;
+  }
+
+  return config.get<T>(reference);
+};
 
 /**
  * Show Feature

--- a/api/test/pact/publish/publish.ts
+++ b/api/test/pact/publish/publish.ts
@@ -54,15 +54,17 @@ const publish = async (): Promise<void> => {
     const configuredConsumerVersion = getConfigValue(PACT_CONSUMER_VERSION);
     const consumerVersion =
       configuredConsumerVersion && configuredConsumerVersion.trim() !== '' ? configuredConsumerVersion : resolveConsumerVersion();
+    const pactBrokerPassword = getConfigValue<string | null>(PACT_BROKER_PASSWORD);
+    const pactBrokerUsername = getConfigValue<string | null>(PACT_BROKER_USERNAME);
 
     const opts = {
       consumerVersion,
       pactBroker,
-      pactBrokerPassword: getConfigValue(PACT_BROKER_PASSWORD),
-      pactBrokerUsername: getConfigValue(PACT_BROKER_USERNAME),
       pactFilesOrDirs: [path.resolve(__dirname, '../pacts/')],
       publishVerificationResult: true,
       tags: [pactTag],
+      ...(pactBrokerPassword ? { pactBrokerPassword } : {}),
+      ...(pactBrokerUsername ? { pactBrokerUsername } : {}),
     };
     await pact.publishPacts(opts);
     console.log('Pact contract publishing complete!');

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -128,8 +128,7 @@
       "mc-idam-client-secret": "IDAM_SECRET",
       "webapp-redis-connection-string": "REDISCLOUD_URL",
       "launch-darkly-client-id": "LAUNCH_DARKLY_CLIENT_ID",
-      "system-user-name": "SYSTEM_USER_NAME",
-      "system-user-password": "SYSTEM_USER_PASSWORD"
+      "system-user-name": "SYSTEM_USER_NAME"
     }
   },
   "caseworkerPageSize": "CASEWORKER_PAGE_SIZE",
@@ -223,8 +222,7 @@
     "brokerUrl": "PACT_BROKER_URL",
     "branchName": "PACT_BRANCH_NAME",
     "consumerVersion": "PACT_CONSUMER_VERSION",
-    "brokerUsername": "PACT_BROKER_USERNAME",
-    "brokerPassword": "PACT_BROKER_PASSWORD"
+    "brokerUsername": "PACT_BROKER_USERNAME"
   },
   "headerConfig": "HEADER_CONFIG"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -216,7 +216,7 @@
     "branchName": "master",
     "brokerUrl": "https://pact-broker.platform.hmcts.net",
     "consumerVersion": "",
-    "brokerUsername": "",
-    "brokerPassword": ""
+    "brokerUsername": null,
+    "brokerPassword": null
   }
 }


### PR DESCRIPTION
### Jira link

See [EXUI-4587](https://tools.hmcts.net/jira/browse/EXUI-4587)

### Change description

This PR fixes the Fortify password-management findings raised against XUI configuration files:

- removes the empty Pact broker password default from `config/default.json`
- removes password entries from `config/custom-environment-variables.json` so Fortify no longer sees password-shaped config values as hardcoded/empty credentials
- keeps runtime support for `SYSTEM_USER_PASSWORD` and `PACT_BROKER_PASSWORD` by resolving those values directly from environment variables in the shared configuration helper
- keeps existing Key Vault/properties-volume fallback behaviour by continuing to call `config.get(...)` when those environment variables are not set
- updates Pact publishing so broker credentials are only passed when configured
- adds direct unit coverage for the new env-only password resolution path and normal config fallback

How this helps us:

- clears the current Fortify noise without removing the real deployment secret contract used by Jenkins, Helm and Key Vault
- keeps credentials out of JSON configuration files while preserving production runtime behaviour
- lowers the chance of future Fortify reoccurrence for the same password keys
- makes the credential resolution behaviour explicit and covered by automated tests, which reduces pipeline/regression risk for auth and Pact publishing paths
- avoids pushing empty password values into Pact publishing options, which is safer for local and CI runs where broker authentication is not configured

### Dependency PRs

N/A

### Testing done

Automated:

- [x] `yarn lint` - passed with 0 errors and the existing warning baseline
- [x] `NODE_CONFIG_DIR=../config node ../node_modules/mocha/bin/mocha.js --config ./test/.mocharc.json -r dotenv-extended/config --spec configuration/index.spec.ts` from `api/` - passed: 1202 passing, 37 pending
- [x] `git diff --check` and `git diff --cached --check` - passed

Manual:

- [x] Verified `SYSTEM_USER_PASSWORD` and `PACT_BROKER_PASSWORD` resolve from environment variables through `getConfigValue`
- [x] Verified the changed JSON config files still parse cleanly

Not run:

- Local Fortify scan was not run; this PR targets the three Fortify findings shown for `config/default.json` and `config/custom-environment-variables.json`.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [ ] Can this PR be released on a Friday (ie: no functional code changes)
