### PR TITLE
ci: point CNP at XUI Jenkins library branch

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -65,7 +65,7 @@ properties([
 
 // use Infrastructure branch in PR for long running FT's beyond 40mins for DEBUG only
 // @Library("Infrastructure@fpl-long-ft-timeout")
-@Library("Infrastructure")
+@Library("Infrastructure@xui-jenkins-8cpu-agent")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -63,9 +63,7 @@ properties([
     ])
 ])
 
-// use Infrastructure branch in PR for long running FT's beyond 40mins for DEBUG only
-// @Library("Infrastructure@fpl-long-ft-timeout")
-@Library("Infrastructure@xui-jenkins-8cpu-agent")
+@Library("Infrastructure")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 


### PR DESCRIPTION
### Jira link

Pending EXUI ticket for the rpx-xui-webapp 8CPU Jenkins agent trial. Jira creation is tracked in the workspace draft because this session does not currently have an authenticated Jira route.

### Change description

Points `Jenkinsfile_CNP` at the temporary `cnp-jenkins-library` branch `xui-jenkins-8cpu-agent` so the CNP pipeline can test the XUI 8CPU Jenkins agent routing.

The webapp CNP and nightly Jenkinsfiles already use `product = "xui"`. This PR only pins CNP to the test library branch while the platform-side agent mapping is under review.

### Dependency PRs

- `cnp-jenkins-config`: https://github.com/hmcts/cnp-jenkins-config/pull/1237
- `cnp-jenkins-library`: https://github.com/hmcts/cnp-jenkins-library/pull/1453
- Related e2e PR update: https://github.com/hmcts/rpx-xui-e2e-tests/pull/45

### Testing done

Automated:

- [x] `git diff --check -- Jenkinsfile_CNP`

Manual:

- [x] Confirmed `Jenkinsfile_CNP` still uses `product = "xui"` and now loads `Infrastructure@xui-jenkins-8cpu-agent`.
- [x] Confirmed the dependency library branch points `TeamConfig` at the matching `cnp-jenkins-config` branch and routes nightly `xui` jobs to the `xui` node label.

Evidence:

- HTML: N/A
- Odhin: N/A
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
