### PR TITLE
fix: remove stale Jenkins library override

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -63,8 +63,6 @@ properties([
     ])
 ])
 
-// use Infrastructure branch in PR for long running FT's beyond 40mins for DEBUG only
-// @Library("Infrastructure@fpl-long-ft-timeout")
 @Library("Infrastructure")
 
 import uk.gov.hmcts.contino.AppPipelineDsl


### PR DESCRIPTION
## What

Remove the stale commented Jenkins shared-library branch override from `Jenkinsfile_CNP`.

The active Jenkinsfiles continue to use the canonical library reference:

```groovy
@Library("Infrastructure")
```

## Why

The old commented override points developers back towards branch-pinned Infrastructure library usage. For the XUI pipeline shape we want the current `Infrastructure` library, which contains the Jenkins agent support and preserves the combined static checks / container build parallel block.

## Validation

- `git diff --check`
- `rg -n '@Library\("Infrastructure' Jenkinsfile*`
- commit hook ran formatting/lint and completed with the existing warning-only baseline (`0 errors`)