### PR TITLE
EXUI-4686 test: stabilise My Work filter tab readiness

### DIFF
--- a/playwright_tests_new/integration/test/manageTasks/myWorkFilters.positive.spec.ts
+++ b/playwright_tests_new/integration/test/manageTasks/myWorkFilters.positive.spec.ts
@@ -2,6 +2,20 @@ import { expect, test } from '../../../E2E/fixtures';
 import { applySessionCookies, myWorkSelectableLocations, setupMyWorkFilterRoutes } from '../../helpers';
 
 const authenticatedUserIdentifier = 'STAFF_ADMIN';
+const myWorkFilterTabs = [
+  {
+    name: 'Available tasks',
+    urlPattern: /\/work\/my-work\/available(?:\?.*)?$/,
+  },
+  {
+    name: 'My cases',
+    urlPattern: /\/work\/my-work\/my-cases(?:\?.*)?$/,
+  },
+  {
+    name: 'My tasks',
+    urlPattern: /\/work\/my-work\/list(?:\?.*)?$/,
+  },
+];
 
 test.describe('My work filter parity', { tag: ['@integration', '@integration-manage-tasks'] }, () => {
   test.beforeEach(async ({ page }) => {
@@ -37,7 +51,7 @@ test.describe('My work filter parity', { tag: ['@integration', '@integration-man
       await expect(taskListPage.taskListFilterToggle).toHaveText('Hide work filter');
       await taskListPage.waitForServiceFilterOptionVisible('Immigration and Asylum');
       await taskListPage.waitForServiceFilterOptionVisible('Social security and child support');
-      await expect(taskListPage.filterPanel).toContainText('Search for a location by name');
+      await expect(taskListPage.filterPanel.locator('#locations:visible').first()).toBeVisible();
 
       await taskListPage.applyCurrentFilters();
       await expect(taskListPage.taskListFilterToggle).toHaveText('Show work filter');
@@ -45,8 +59,11 @@ test.describe('My work filter parity', { tag: ['@integration', '@integration-man
     });
 
     await test.step('Verify the same Services and Locations filter surface on Available tasks, My cases, and My tasks', async () => {
-      for (const tabName of ['Available tasks', 'My cases', 'My tasks']) {
-        await taskListPage.taskTableTabs.filter({ hasText: tabName }).first().click();
+      for (const { name: tabName, urlPattern } of myWorkFilterTabs) {
+        await Promise.all([
+          page.waitForURL(urlPattern, { timeout: 30_000 }),
+          taskListPage.taskTableTabs.filter({ hasText: tabName }).first().click(),
+        ]);
         await taskListPage.waitForTaskListShellReady(`${tabName} filter parity`);
         await expect(taskListPage.taskListFilterToggle).toHaveText('Show work filter');
 
@@ -54,7 +71,7 @@ test.describe('My work filter parity', { tag: ['@integration', '@integration-man
         await expect(taskListPage.taskListFilterToggle).toHaveText('Hide work filter');
         await taskListPage.waitForServiceFilterOptionVisible('Immigration and Asylum');
         await taskListPage.waitForServiceFilterOptionVisible('Social security and child support');
-        await expect(taskListPage.filterPanel).toContainText('Search for a location by name');
+        await expect(taskListPage.filterPanel.locator('#locations:visible').first()).toBeVisible();
 
         await taskListPage.applyCurrentFilters();
         await expect(taskListPage.taskListFilterToggle).toHaveText('Show work filter');


### PR DESCRIPTION
## Summary
- wait for exact My Work tab route changes before asserting the filter shell
- assert the mounted Locations control with #locations:visible instead of broad duplicated panel text
- follow-up for EXUI-4686 / PR #5209 Jenkins Preview Playwright Integration flake

## Jira
- EXUI-4686

## Evidence
- yarn eslint playwright_tests_new/integration/test/manageTasks/myWorkFilters.positive.spec.ts
- PLAYWRIGHT_SKIP_INSTALL=true PW_INTEGRATION_SESSION_WARMUP_USERS=@none FUNCTIONAL_TESTS_WORKERS=1 yarn test:playwright:integration -- playwright_tests_new/integration/test/manageTasks/myWorkFilters.positive.spec.ts --project=chromium --repeat-each=5
- git diff --check origin/master...HEAD

## AI assistance
AI-assisted change prepared under HMCTS agent controls; requires human review before merge.