### PR TITLE
fix: retain PSWritePDF automation module

### DIFF
--- a/infrastructure/automation.tf
+++ b/infrastructure/automation.tf
@@ -635,3 +635,17 @@ resource "azurerm_automation_module" "az_communication" {
     uri = "https://www.powershellgallery.com/api/v2/package/Az.Communication/1.2.0"
   }
 }
+
+# Retain the existing production module in Terraform state. The runbook no longer
+# imports PSWritePDF, but removing this resource plans a delete blocked by the
+# production resource-group lock.
+resource "azurerm_automation_module" "ps_write_pdf" {
+  count                   = var.welsh_reporting_enabled ? 1 : 0
+  name                    = "PSWritePDF"
+  resource_group_name     = azurerm_resource_group.rg.name
+  automation_account_name = azurerm_automation_account.welsh_reporting.0.name
+
+  module_link {
+    uri = "https://www.powershellgallery.com/api/v2/package/PSWritePDF"
+  }
+}


### PR DESCRIPTION
## Summary
- Retain the existing `PSWritePDF` Azure Automation module in Terraform configuration.
- Keep the Welsh report runbook independent of `PSWritePDF`; the retained resource prevents Terraform from planning a locked production delete.

## Context
Production `master` apply failed while deleting `/modules/PSWritePDF` with `409 ScopeLocked` because the `xui-webapp-prod` resource group is locked. The module still exists in Terraform state, so removing it from configuration causes Terraform to plan a delete. This PR keeps the resource declared until a controlled cleanup can remove it with the required lock/state change process.

## Validation
- `terraform -chdir=/Users/andrew.grizhenkov/HMCTS/dev/PROJECTS/rpx-xui-webapp-pswritepdf-hotfix/infrastructure fmt -check -diff automation.tf provider.tf`
- `git -C /Users/andrew.grizhenkov/HMCTS/dev/PROJECTS/rpx-xui-webapp-pswritepdf-hotfix diff --check`

`terraform validate -no-color` was attempted but the fresh hotfix worktree has not run `terraform init`, so local modules were not installed (`redis6-cache`, `application_insights`).

## AI assistance
AI-assisted investigation and patch preparation; human review required before merge.