### PR TITLE
tightening up null check on getLocationById

### DIFF
--- a/api/prd/location/index.spec.ts
+++ b/api/prd/location/index.spec.ts
@@ -105,5 +105,49 @@ describe('prd Locations', () => {
         throw new Error(err);
       }
     });
+
+    it('should not append service_code when serviceCode query param is a null-like string', async () => {
+      spy = sandbox.stub(http, GET).resolves(getLocationByIdRes);
+      const req = mockReq({
+        query: {
+          epimms_id: '2345',
+          serviceCode: 'null',
+        },
+      });
+
+      const response = mockRes();
+
+      try {
+        await getLocationById(req, response, next);
+        expect(spy.firstCall.args[0]).to.contain('/refdata/location/court-venues?epimms_id=2345');
+        expect(spy.firstCall.args[0]).to.not.contain('service_code=');
+        expect(response.status).to.have.been.calledWith(200);
+      } catch (err) {
+        console.log(err.stack);
+        throw new Error(err);
+      }
+    });
+
+    it('should not append service_code when serviceCode query param is undefined', async () => {
+      spy = sandbox.stub(http, GET).resolves(getLocationByIdRes);
+      const req = mockReq({
+        query: {
+          epimms_id: '2345',
+          serviceCode: undefined,
+        },
+      });
+
+      const response = mockRes();
+
+      try {
+        await getLocationById(req, response, next);
+        expect(spy.firstCall.args[0]).to.contain('/refdata/location/court-venues?epimms_id=2345');
+        expect(spy.firstCall.args[0]).to.not.contain('service_code=');
+        expect(response.status).to.have.been.calledWith(200);
+      } catch (err) {
+        console.log(err.stack);
+        throw new Error(err);
+      }
+    });
   });
 });

--- a/api/prd/location/index.ts
+++ b/api/prd/location/index.ts
@@ -11,6 +11,7 @@ import * as log4jui from '../../lib/log4jui';
 
 const url: string = getConfigValue(SERVICES_PRD_LOCATION_API);
 const logger: JUILogger = log4jui.getLogger('location hearings');
+const INVALID_SERVICE_CODE_VALUES = new Set(['null', 'undefined']);
 /**
  * @description getLocations from service ID/location type/search term
  * @overview API sample: /api/locations/getLocations?serviceIds=BBA3,BFA1&locationType=hearing&searchTerm=CT91RL
@@ -50,7 +51,7 @@ export async function getLocations(req: EnhancedRequest, res: Response, next: Ne
  */
 export async function getLocationById(req: EnhancedRequest, res: Response, next: NextFunction) {
   const epimmsID = req.query.epimms_id;
-  const serviceCode = req.query.serviceCode && req.query.serviceCode !== '' ? (req.query.serviceCode as string) : null;
+  const serviceCode = getValidServiceCode(req.query.serviceCode);
   delete req.query.serviceCode;
   const serviceCodeParam = serviceCode ? `&service_code=${serviceCode}` : '';
   const markupPath: string = `${url}/refdata/location/court-venues?epimms_id=${epimmsID}${serviceCodeParam}`;
@@ -87,4 +88,18 @@ function getIdenticalLocationByEpimmsId(data: LocationModel[]): LocationByEpimms
 
 function getLocationsByCourtType(locations: LocationModel[], courtTypeIdsArray: string[]): LocationModel[] {
   return locations.filter((location) => courtTypeIdsArray.includes(location.court_type_id));
+}
+
+function getValidServiceCode(serviceCodeQuery: unknown): string | null {
+  const serviceCodeValue = Array.isArray(serviceCodeQuery) ? serviceCodeQuery[0] : serviceCodeQuery;
+  if (typeof serviceCodeValue !== 'string') {
+    return null;
+  }
+
+  const cleanedServiceCode = serviceCodeValue.trim();
+  if (!cleanedServiceCode || INVALID_SERVICE_CODE_VALUES.has(cleanedServiceCode.toLowerCase())) {
+    return null;
+  }
+
+  return cleanedServiceCode;
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/POFCC-137

### Change description

code was not handling a text value of null and so was passing this as a service code and so generating a 404 error.  Better processing has been introduced to cope with null values being passed in and so not passing the service code input in.

### Dependency PRs

https://github.com/hmcts/rpx-xui-webapp/pull/5194

### Testing done

The error was seen to occur without the change and with the change, the value of null is recognised and treated appropriately and the 404 error can be seen to have been prevented. 

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [ ] Can this PR be released on a Friday (ie: no functional code changes)