### PR TITLE
EXUI-4843 Skip hidden divorce reason selection

### DIFF
--- a/playwright_tests_new/E2E/page-objects/pages/exui/createCase.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/createCase.po.ts
@@ -1099,8 +1099,7 @@ export class CreateCasePage extends Base {
       const divorceReasonCheckbox = divorceReasonField.getByLabel(reason, { exact: true }).first();
       const divorceReasonLabel = divorceReasonField.locator('label').filter({ hasText: reason }).first();
       if (!(await divorceReasonLabel.isVisible().catch(() => false))) {
-        const visibleReasonCount = await divorceReasonField.locator('label:visible').count();
-        if (visibleReasonCount === 0) {
+        if ((await divorceReasonField.locator('label:visible').count()) === 0) {
           return;
         }
         throw new Error(`Divorce reason "${reason}" is not visible`);

--- a/playwright_tests_new/E2E/page-objects/pages/exui/createCase.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/createCase.po.ts
@@ -1098,6 +1098,13 @@ export class CreateCasePage extends Base {
     for (const reason of reasons) {
       const divorceReasonCheckbox = divorceReasonField.getByLabel(reason, { exact: true }).first();
       const divorceReasonLabel = divorceReasonField.locator('label').filter({ hasText: reason }).first();
+      if (!(await divorceReasonLabel.isVisible().catch(() => false))) {
+        const visibleReasonCount = await divorceReasonField.locator('label:visible').count();
+        if (visibleReasonCount === 0) {
+          return;
+        }
+        throw new Error(`Divorce reason "${reason}" is not visible`);
+      }
       await divorceReasonLabel.click({ timeout: EXUI_TIMEOUTS.POC_FIELD_VISIBLE });
       if (!(await divorceReasonCheckbox.isChecked({ timeout: EXUI_TIMEOUTS.POC_FIELD_VISIBLE }).catch(() => false))) {
         throw new Error(`Divorce reason "${reason}" was not checked after clicking its label`);


### PR DESCRIPTION
### Jira link

See [EXUI-4843](https://tools.hmcts.net/jira/browse/EXUI-4843)

### Change description

This PR fixes a nightly integration failure in the divorce create-case journey.

The failing test was trying to select `Adultery` from `DivorceReason` after `TextField0` had been set to `Hide all`. In that scenario the CCD show condition intentionally hides the whole `DivorceReason` field group, so Playwright could still resolve the label in the DOM but could not perform a real user click because the label was not visible.

The fix keeps the existing user-level label click for the normal visible path, but skips divorce reason selection when the whole `DivorceReason` group has no visible labels. If the group is visible and a requested reason is missing or hidden, the helper still fails loudly. That is intentional: we only want to handle the legitimate hidden-field case, not hide a broken visible form.

I have not changed this back to checkbox `check()` because that would not address the nightly failure. The problem was not the click method; the control was intentionally hidden by the show condition. Moving back to `check()` would still be acting on a hidden/styled control and risks weakening the visible-path behaviour that the label click already stabilises.

No extra test was added because the existing hidden/omitted-fields scenario already proves the important contract:

- check-your-answers does not show `Choose divorce reasons`
- the create-case request body does not contain `DivorceReason`

### Dependency PRs

N/A

### Testing done

Automated:

- [x] `yarn lint` - passed with the existing repo warning baseline: 0 errors, 435 warnings.
- [x] `node ./node_modules/eslint/bin/eslint.js playwright_tests_new/E2E/page-objects/pages/exui/createCase.po.ts` - passed.
- [x] `git diff --check` - passed.
- [x] `yarn npm audit --recursive --environment production --json` - completed with the existing production advisory baseline and no dependency changes in this PR.
- [x] Focused hidden/omitted-fields create-case integration scenario - passed locally.
- [x] Focused visible all-fields create-case integration scenario - passed locally.
- [x] Jenkins PR checks - passed on PR #5250 build #2.

Manual:

- [x] Reviewed the nightly failure and confirmed the failed action was trying to click a label that was intentionally hidden after `TextField0 = Hide all`.
- [x] Reviewed the helper boundary to make sure it does not silently skip partially broken visible `DivorceReason` controls.

Evidence:

- HTML: N/A for focused local grep runs.
- Odhin: N/A for focused local grep runs.
- JUnit: N/A for focused local grep runs.
- Jenkins: [PR #5250 build #2](https://build.hmcts.net/job/HMCTS_j_to_z/job/rpx-xui-webapp/job/PR-5250/2/display/redirect)

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

Audit note: `yarn npm audit --recursive --environment production --json` reports existing advisories/deprecations including `form-data`, `http-proxy-middleware`, `dompurify`, and `uuid`. This PR changes only Playwright test code and does not modify dependency manifests or suppressions.

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
