### PR TITLE
EXUI-4132 Add query management negative coverage

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -70,7 +70,7 @@ properties([
 
 // use Infrastructure branch in PR for long running FT's beyond 40mins for DEBUG only
 // @Library("Infrastructure@fpl-long-ft-timeout")
-@Library("Infrastructure@2.0.0")
+@Library("Infrastructure")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -70,7 +70,7 @@ properties([
 
 // use Infrastructure branch in PR for long running FT's beyond 40mins for DEBUG only
 // @Library("Infrastructure@fpl-long-ft-timeout")
-@Library("Infrastructure")
+@Library("Infrastructure@2.0.0")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 

--- a/playwright_tests_new/E2E/page-objects/pages/exui/queryManagement.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/queryManagement.po.ts
@@ -9,6 +9,10 @@ export class QueryManagementPage extends Base {
   readonly respondQueryForm = this.content.locator('ccd-query-write-respond-to-query');
   readonly reviewQueryDetails = this.content.locator('ccd-query-check-your-answers');
   readonly confirmation = this.content.locator('ccd-query-confirmation');
+  readonly errorSummary = this.content.locator('.govuk-error-summary, .error-summary').first();
+  readonly errorSummaryTitle = this.errorSummary.locator('h2, h3').first();
+  readonly validationErrors = this.errorSummary.locator('.validation-error');
+  readonly eventCreationErrorHeading = this.page.getByRole('heading', { name: 'The event could not be created' });
 
   readonly raiseANewQueryHeading = this.qualifyingQuestionOptions.locator('h1.govuk-fieldset__heading');
   readonly raiseANewQueryRadio = this.qualifyingQuestionOptions.locator(

--- a/playwright_tests_new/integration/helpers/queryManagementMockRoutes.helper.ts
+++ b/playwright_tests_new/integration/helpers/queryManagementMockRoutes.helper.ts
@@ -64,6 +64,11 @@ export type QueryManagementSubmissionCapture = {
   submittedEvents: QueryManagementSubmittedEvent[];
 };
 
+type QueryManagementRouteOverride = {
+  body?: unknown;
+  status?: number;
+};
+
 type QueryManagementRouteUser = 'solicitor' | 'caseworker';
 
 type QueryManagementMockRoutesOptions = {
@@ -71,6 +76,10 @@ type QueryManagementMockRoutesOptions = {
   completableTasks?: unknown[];
   includeQueryTab?: boolean;
   queryCollection?: QueryManagementCaseQueriesCollection;
+  raiseQueryEventTrigger?: QueryManagementRouteOverride;
+  respondQueryEventTrigger?: QueryManagementRouteOverride;
+  submitQueryEvent?: QueryManagementRouteOverride;
+  validateQueryEvent?: QueryManagementRouteOverride;
   user?: QueryManagementRouteUser;
 };
 
@@ -91,6 +100,19 @@ async function fulfillJson(route: Route, body: unknown, status = 200): Promise<v
     status,
     contentType: 'application/json',
     body: JSON.stringify(body),
+  });
+}
+
+async function fulfillJsonRoute(
+  route: Route,
+  override: QueryManagementRouteOverride | undefined,
+  fallbackBody: unknown,
+  fallbackStatus = 200
+): Promise<void> {
+  await route.fulfill({
+    status: override?.status ?? fallbackStatus,
+    contentType: 'application/json',
+    body: JSON.stringify(override?.body ?? fallbackBody),
   });
 }
 
@@ -281,47 +303,55 @@ export async function setupQueryManagementMockRoutes(
   await page.route(
     `**/data/internal/cases/${QUERY_MANAGEMENT_CASE_REFERENCE}/event-triggers/${QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_ID}/validate*`,
     async (route) => {
-      await fulfillJson(route, raiseQueryEventTrigger);
+      await fulfillJsonRoute(route, options.raiseQueryEventTrigger, raiseQueryEventTrigger);
     }
   );
 
   await page.route(
     `**/data/internal/cases/${QUERY_MANAGEMENT_CASE_REFERENCE}/event-triggers/${QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_ID}*`,
     async (route) => {
-      await fulfillJson(route, raiseQueryEventTrigger);
+      await fulfillJsonRoute(route, options.raiseQueryEventTrigger, raiseQueryEventTrigger);
     }
   );
 
   await page.route(
     `**/data/internal/cases/${QUERY_MANAGEMENT_CASE_REFERENCE}/event-triggers/${QUERY_MANAGEMENT_RESPOND_QUERY_TRIGGER_ID}/validate*`,
     async (route) => {
-      await fulfillJson(route, respondQueryEventTrigger);
+      await fulfillJsonRoute(route, options.respondQueryEventTrigger, respondQueryEventTrigger);
     }
   );
 
   await page.route(
     `**/data/internal/cases/${QUERY_MANAGEMENT_CASE_REFERENCE}/event-triggers/${QUERY_MANAGEMENT_RESPOND_QUERY_TRIGGER_ID}*`,
     async (route) => {
-      await fulfillJson(route, respondQueryEventTrigger);
+      await fulfillJsonRoute(route, options.respondQueryEventTrigger, respondQueryEventTrigger);
     }
   );
 
   await page.route(`**/data/case-types/${QUERY_MANAGEMENT_CASE_TYPE}/validate*`, async (route) => {
-    await fulfillJson(route, buildQueryManagementValidationResponse(route));
+    await fulfillJsonRoute(route, options.validateQueryEvent, buildQueryManagementValidationResponse(route));
   });
 
   await page.route(`**/data/cases/${QUERY_MANAGEMENT_CASE_REFERENCE}/events*`, async (route) => {
     const submittedEvent = route.request().postDataJSON?.() as QueryManagementSubmittedEvent;
     capture.submittedEvents.push(submittedEvent);
+    const successfulSubmit =
+      !options.submitQueryEvent?.status || (options.submitQueryEvent.status >= 200 && options.submitQueryEvent.status < 300);
 
-    const submittedQueryCollection = submittedEvent.data?.[QUERY_MANAGEMENT_CASE_QUERIES_FIELD_ID] as
-      | QueryManagementCaseQueriesCollection
-      | undefined;
-    if (submittedQueryCollection) {
-      queryCollection = submittedQueryCollection;
+    if (successfulSubmit) {
+      const submittedQueryCollection = submittedEvent.data?.[QUERY_MANAGEMENT_CASE_QUERIES_FIELD_ID] as
+        | QueryManagementCaseQueriesCollection
+        | undefined;
+      if (submittedQueryCollection) {
+        queryCollection = submittedQueryCollection;
+      }
     }
 
-    await fulfillJson(route, buildQueryManagementCreateEventResponse(route, buildCaseDetails()));
+    await fulfillJsonRoute(
+      route,
+      options.submitQueryEvent,
+      successfulSubmit ? buildQueryManagementCreateEventResponse(route, buildCaseDetails()) : { message: 'query-submit-failed' }
+    );
   });
 
   return capture;

--- a/playwright_tests_new/integration/test/queryManagement/queryManagement.negative.spec.ts
+++ b/playwright_tests_new/integration/test/queryManagement/queryManagement.negative.spec.ts
@@ -84,21 +84,25 @@ test.describe('Query Management negative integration', { tag: ['@integration', '
         response.status() === 500
     );
 
-    await caseDetailsPage.openCaseDetails(
-      QUERY_MANAGEMENT_JURISDICTION,
-      QUERY_MANAGEMENT_CASE_TYPE,
-      QUERY_MANAGEMENT_CASE_REFERENCE
-    );
-    await caseDetailsPage.selectCaseAction(QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_NAME, {
-      expectedLocator: queryManagementPage.raiseANewQueryHeading,
-      expectedPath: new RegExp(`/query-management/query/${QUERY_MANAGEMENT_CASE_REFERENCE}(?:$|[/?#])`),
+    await test.step('Open the raise-query journey from case actions', async () => {
+      await caseDetailsPage.openCaseDetails(
+        QUERY_MANAGEMENT_JURISDICTION,
+        QUERY_MANAGEMENT_CASE_TYPE,
+        QUERY_MANAGEMENT_CASE_REFERENCE
+      );
+      await caseDetailsPage.selectCaseAction(QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_NAME, {
+        expectedLocator: queryManagementPage.raiseANewQueryHeading,
+        expectedPath: new RegExp(`/query-management/query/${QUERY_MANAGEMENT_CASE_REFERENCE}(?:$|[/?#])`),
+      });
+      await queryManagementPage.chooseRaiseAQueryJourney();
+      await failedTriggerResponse;
     });
-    await queryManagementPage.chooseRaiseAQueryJourney();
-    await failedTriggerResponse;
 
-    await expect(page.getByText('query-event-trigger-failed', { exact: true })).toBeVisible();
-    await expect(queryManagementPage.continueButton).not.toBeVisible();
-    expect(submissionCapture.submittedEvents).toHaveLength(0);
+    await test.step('Verify the trigger failure is shown without submitting an event', async () => {
+      await expect(page.getByText('query-event-trigger-failed', { exact: true })).toBeVisible();
+      await expect(queryManagementPage.continueButton).not.toBeVisible();
+      expect(submissionCapture.submittedEvents).toHaveLength(0);
+    });
   });
 
   test('shows an event creation error and stays on review when query submission fails', async ({
@@ -113,32 +117,36 @@ test.describe('Query Management negative integration', { tag: ['@integration', '
         body: { message: 'query-submit-failed' },
       },
     });
-    await caseDetailsPage.openCaseDetails(
-      QUERY_MANAGEMENT_JURISDICTION,
-      QUERY_MANAGEMENT_CASE_TYPE,
-      QUERY_MANAGEMENT_CASE_REFERENCE
-    );
-    await caseDetailsPage.selectCaseAction(QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_NAME, {
-      expectedLocator: queryManagementPage.raiseANewQueryHeading,
-      expectedPath: new RegExp(`/query-management/query/${QUERY_MANAGEMENT_CASE_REFERENCE}(?:$|[/?#])`),
+    await test.step('Open the review page with query details', async () => {
+      await caseDetailsPage.openCaseDetails(
+        QUERY_MANAGEMENT_JURISDICTION,
+        QUERY_MANAGEMENT_CASE_TYPE,
+        QUERY_MANAGEMENT_CASE_REFERENCE
+      );
+      await caseDetailsPage.selectCaseAction(QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_NAME, {
+        expectedLocator: queryManagementPage.raiseANewQueryHeading,
+        expectedPath: new RegExp(`/query-management/query/${QUERY_MANAGEMENT_CASE_REFERENCE}(?:$|[/?#])`),
+      });
+      await queryManagementPage.chooseRaiseAQueryJourney();
+      await queryManagementPage.enterQueryDetailsAndContinue('Submission failure subject', 'Submission failure details');
+      await expect(queryManagementPage.reviewQueryDetailsHeading).toBeVisible();
     });
-    await queryManagementPage.chooseRaiseAQueryJourney();
-    await queryManagementPage.enterQueryDetailsAndContinue('Submission failure subject', 'Submission failure details');
-    await expect(queryManagementPage.reviewQueryDetailsHeading).toBeVisible();
 
-    const failedSubmitResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes(`/data/cases/${QUERY_MANAGEMENT_CASE_REFERENCE}/events`) &&
-        response.request().method() === 'POST' &&
-        response.status() === 500
-    );
+    await test.step('Submit and verify the review page shows the event creation error', async () => {
+      const failedSubmitResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes(`/data/cases/${QUERY_MANAGEMENT_CASE_REFERENCE}/events`) &&
+          response.request().method() === 'POST' &&
+          response.status() === 500
+      );
 
-    await queryManagementPage.submitQuery();
-    await failedSubmitResponse;
+      await queryManagementPage.submitQuery();
+      await failedSubmitResponse;
 
-    await expect(queryManagementPage.reviewQueryDetailsHeading).toBeVisible();
-    await expect(queryManagementPage.eventCreationErrorHeading).toBeVisible();
-    await expect(queryManagementPage.querySubmittedHeading).not.toBeVisible();
-    expect(submissionCapture.submittedEvents).toHaveLength(1);
+      await expect(queryManagementPage.reviewQueryDetailsHeading).toBeVisible();
+      await expect(queryManagementPage.eventCreationErrorHeading).toBeVisible();
+      await expect(queryManagementPage.querySubmittedHeading).not.toBeVisible();
+      expect(submissionCapture.submittedEvents).toHaveLength(1);
+    });
   });
 });

--- a/playwright_tests_new/integration/test/queryManagement/queryManagement.negative.spec.ts
+++ b/playwright_tests_new/integration/test/queryManagement/queryManagement.negative.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from '../../../E2E/fixtures';
+import { openSolicitorRaiseQueryFromNextStep, setupQueryManagementMockRoutes } from '../../helpers';
+import {
+  buildQueryManagementExistingQueryCollection,
+  QUERY_MANAGEMENT_CASE_REFERENCE,
+  QUERY_MANAGEMENT_CASE_TYPE,
+  QUERY_MANAGEMENT_JURISDICTION,
+  QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_NAME,
+} from '../../mocks/queryManagement.mock';
+import { applySessionCookies } from '../../../common/sessionCapture';
+import { TEST_USERS } from '../../testData';
+
+test.describe('Query Management negative integration', { tag: ['@integration', '@integration-query-management'] }, () => {
+  test('shows validation when a solicitor continues without choosing a query option', async ({
+    page,
+    caseDetailsPage,
+    queryManagementPage,
+  }) => {
+    const submissionCapture = await openSolicitorRaiseQueryFromNextStep(page, caseDetailsPage, queryManagementPage);
+
+    await queryManagementPage.continueButton.click();
+
+    await expect(queryManagementPage.errorSummaryTitle).toHaveText('There is a problem');
+    await expect(queryManagementPage.validationErrors).toContainText(['Select an option']);
+    await expect(queryManagementPage.raiseANewQueryHeading).toBeVisible();
+    expect(submissionCapture.submittedEvents).toHaveLength(0);
+  });
+
+  test('shows validation when a solicitor continues without mandatory query details', async ({
+    page,
+    caseDetailsPage,
+    queryManagementPage,
+  }) => {
+    const submissionCapture = await openSolicitorRaiseQueryFromNextStep(page, caseDetailsPage, queryManagementPage);
+
+    await queryManagementPage.chooseRaiseAQueryJourney();
+    await queryManagementPage.continueButton.click();
+
+    await expect(page).toHaveURL(new RegExp(`/query-management/query/${QUERY_MANAGEMENT_CASE_REFERENCE}/raiseAQuery(?:$|[/?#])`));
+    await expect(queryManagementPage.errorSummaryTitle).toHaveText('There is a problem');
+    await expect(queryManagementPage.validationErrors).toContainText([
+      'Enter a query subject',
+      'Enter query details',
+      'Select whether the query is hearing related or not',
+    ]);
+    await expect(queryManagementPage.enterQueryDetailsHeading).toBeVisible();
+    expect(submissionCapture.submittedEvents).toHaveLength(0);
+  });
+
+  test('shows the case-not-configured validation when the requested query cannot be resolved', async ({
+    page,
+    queryManagementPage,
+  }) => {
+    await applySessionCookies(page, TEST_USERS.SOLICITOR);
+    const submissionCapture = await setupQueryManagementMockRoutes(page, {
+      includeQueryTab: true,
+      queryCollection: buildQueryManagementExistingQueryCollection({ includeResponse: true }),
+      user: 'solicitor',
+    });
+
+    await page.goto(`/query-management/query/${QUERY_MANAGEMENT_CASE_REFERENCE}/4/missing-query-id`);
+
+    await expect(queryManagementPage.errorSummaryTitle).toHaveText('There is a problem');
+    await expect(queryManagementPage.validationErrors).toContainText(['This case is not configured for query management.']);
+    expect(submissionCapture.submittedEvents).toHaveLength(0);
+  });
+
+  test('shows a query setup error when the raise-query event trigger fails', async ({
+    page,
+    caseDetailsPage,
+    queryManagementPage,
+  }) => {
+    await applySessionCookies(page, TEST_USERS.SOLICITOR);
+    const submissionCapture = await setupQueryManagementMockRoutes(page, {
+      raiseQueryEventTrigger: {
+        status: 500,
+        body: { message: 'query-event-trigger-failed' },
+      },
+    });
+    const failedTriggerResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/event-triggers/queryManagementRaiseQuery`) &&
+        response.request().method() === 'GET' &&
+        response.status() === 500
+    );
+
+    await caseDetailsPage.openCaseDetails(
+      QUERY_MANAGEMENT_JURISDICTION,
+      QUERY_MANAGEMENT_CASE_TYPE,
+      QUERY_MANAGEMENT_CASE_REFERENCE
+    );
+    await caseDetailsPage.selectCaseAction(QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_NAME, {
+      expectedLocator: queryManagementPage.raiseANewQueryHeading,
+      expectedPath: new RegExp(`/query-management/query/${QUERY_MANAGEMENT_CASE_REFERENCE}(?:$|[/?#])`),
+    });
+    await queryManagementPage.chooseRaiseAQueryJourney();
+    await failedTriggerResponse;
+
+    await expect(page.getByText('query-event-trigger-failed', { exact: true })).toBeVisible();
+    await expect(queryManagementPage.continueButton).not.toBeVisible();
+    expect(submissionCapture.submittedEvents).toHaveLength(0);
+  });
+
+  test('shows an event creation error and stays on review when query submission fails', async ({
+    page,
+    caseDetailsPage,
+    queryManagementPage,
+  }) => {
+    await applySessionCookies(page, TEST_USERS.SOLICITOR);
+    const submissionCapture = await setupQueryManagementMockRoutes(page, {
+      submitQueryEvent: {
+        status: 500,
+        body: { message: 'query-submit-failed' },
+      },
+    });
+    await caseDetailsPage.openCaseDetails(
+      QUERY_MANAGEMENT_JURISDICTION,
+      QUERY_MANAGEMENT_CASE_TYPE,
+      QUERY_MANAGEMENT_CASE_REFERENCE
+    );
+    await caseDetailsPage.selectCaseAction(QUERY_MANAGEMENT_RAISE_QUERY_TRIGGER_NAME, {
+      expectedLocator: queryManagementPage.raiseANewQueryHeading,
+      expectedPath: new RegExp(`/query-management/query/${QUERY_MANAGEMENT_CASE_REFERENCE}(?:$|[/?#])`),
+    });
+    await queryManagementPage.chooseRaiseAQueryJourney();
+    await queryManagementPage.enterQueryDetailsAndContinue('Submission failure subject', 'Submission failure details');
+    await expect(queryManagementPage.reviewQueryDetailsHeading).toBeVisible();
+
+    const failedSubmitResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/data/cases/${QUERY_MANAGEMENT_CASE_REFERENCE}/events`) &&
+        response.request().method() === 'POST' &&
+        response.status() === 500
+    );
+
+    await queryManagementPage.submitQuery();
+    await failedSubmitResponse;
+
+    await expect(queryManagementPage.reviewQueryDetailsHeading).toBeVisible();
+    await expect(queryManagementPage.eventCreationErrorHeading).toBeVisible();
+    await expect(queryManagementPage.querySubmittedHeading).not.toBeVisible();
+    expect(submissionCapture.submittedEvents).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
### Jira link

See [EXUI-4132](https://tools.hmcts.net/jira/browse/EXUI-4132)

### Change description

Adds Query Management negative integration coverage for the solicitor raise-query journey.

This PR adds a dedicated negative spec and extends the existing Query Management route helper so the integration suite can drive realistic validation and backend-failure states without product code changes.

### Value added

This strengthens the test pack around the failure paths that are easy to miss when only happy-path Query Management coverage exists.

The new tests prove that the UI blocks progression when the solicitor does not choose a qualifying option, shows the expected validation when required query details are missing, handles an unresolved query id without submitting data, surfaces an event-trigger failure, and stays on the review screen when event submission fails.

The main value is regression protection around user-visible error handling. If a future change accidentally lets a solicitor submit an incomplete query, hides a required validation message, routes to the wrong Query Management screen, or treats a failed CCD event submission as successful, this pack should fail in the focused Query Management integration area rather than relying on manual exploratory checks.

It also gives us better confidence that the Query Management mock route helper can model non-2xx CCD responses in a controlled way, which makes future negative coverage cheaper without introducing product/runtime changes.

### Dependency PRs

None.

### Testing done

- `yarn lint:prettier playwright_tests_new/E2E/page-objects/pages/exui/queryManagement.po.ts playwright_tests_new/integration/helpers/queryManagementMockRoutes.helper.ts playwright_tests_new/integration/test/queryManagement/queryManagement.negative.spec.ts`
- `PW_INTEGRATION_SESSION_WARMUP_USERS=@none PLAYWRIGHT_SKIP_INSTALL=true PLAYWRIGHT_REPORTERS=list,html yarn test:playwright:integration -- playwright_tests_new/integration/test/queryManagement/queryManagement.negative.spec.ts --workers=1`
- `git diff --check origin/master...HEAD`

Focused integration result: 5 passed, 0 flaky.

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
