### PR TITLE
EXUI-4514 Add CCD toolkit field permission coverage

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -70,7 +70,7 @@ properties([
 
 // use Infrastructure branch in PR for long running FT's beyond 40mins for DEBUG only
 // @Library("Infrastructure@fpl-long-ft-timeout")
-@Library("Infrastructure@2.0.0")
+@Library("Infrastructure")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -70,7 +70,7 @@ properties([
 
 // use Infrastructure branch in PR for long running FT's beyond 40mins for DEBUG only
 // @Library("Infrastructure@fpl-long-ft-timeout")
-@Library("Infrastructure")
+@Library("Infrastructure@2.0.0")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 

--- a/playwright_tests_new/api/unit/search-case-session.unit.api.ts
+++ b/playwright_tests_new/api/unit/search-case-session.unit.api.ts
@@ -39,6 +39,17 @@ test.describe('search case session helper', { tag: '@svc-internal' }, () => {
     ).toEqual(['RESTRICTED_CASE_FILE_VIEW_ON', 'FPL_GLOBAL_SEARCH', 'SEARCH_EMPLOYMENT_CASE']);
   });
 
+  test('prewarms the solicitor session for targeted CCD toolkit integration runs', () => {
+    expect(
+      resolveIntegrationSessionWarmupUsers({} as NodeJS.ProcessEnv, {
+        includeTags: ['@integration-ccd-toolkit'],
+        excludedTags: [],
+        availableTags: ['@integration', '@integration-ccd-toolkit', '@integration-create-case'],
+        suiteTag: '@integration',
+      })
+    ).toEqual(['SOLICITOR']);
+  });
+
   test('prewarms only the shared contention sessions for full integration runs', () => {
     expect(
       resolveIntegrationSessionWarmupUsers({} as NodeJS.ProcessEnv, {

--- a/playwright_tests_new/integration/helpers/searchCaseSession.helper.ts
+++ b/playwright_tests_new/integration/helpers/searchCaseSession.helper.ts
@@ -34,6 +34,7 @@ const integrationWarmupUsersByTag: Record<string, IntegrationWarmupResolver> = {
   [caseFileViewIntegrationTag]: () => [caseFileViewUser],
   '@integration-case-linking': () => ['STAFF_ADMIN', 'IAC_Judge_WA_R1'],
   '@integration-case-list': () => ['SOLICITOR'],
+  '@integration-ccd-toolkit': () => ['SOLICITOR'],
   '@integration-create-case': () => ['SOLICITOR'],
   '@integration-hearings': (env) => {
     const onUsers = getConfiguredHearingManagerUserIdentifiers(HEARING_MANAGER_CR84_ON_USER, env);

--- a/playwright_tests_new/integration/mocks/createCase.mock.ts
+++ b/playwright_tests_new/integration/mocks/createCase.mock.ts
@@ -190,6 +190,11 @@ export type CreateCaseAclCrudOverrides = {
 
 export type CreateCaseAclGroupInput = string[] | CreateCaseAclCrudOverrides[];
 
+type DivorcePocCaseDataOptions = {
+  peopleDisplayContextParameter?: string | null;
+  peopleValue?: unknown;
+};
+
 const CREATE_CASE_DEFAULT_CRUD: Omit<CreateCaseAcl, 'role'> = {
   create: true,
   read: true,
@@ -228,7 +233,12 @@ const CREATE_CASE_ACLS_WITH_READONLY_COURTADMIN = CREATE_CASE_SHARED_ACLS.map((a
   acl.role === 'caseworker-divorce-courtadmin' ? { ...acl, update: false, delete: false } : acl
 );
 
-export function divorcePocCaseData() {
+export function divorcePocCaseData(options: DivorcePocCaseDataOptions = {}) {
+  const peopleDisplayContextParameter =
+    'peopleDisplayContextParameter' in options
+      ? options.peopleDisplayContextParameter
+      : '#COLLECTION(allowDelete,allowInsert,allowUpdate)';
+
   return {
     id: 'createCase',
     name: 'Create a case',
@@ -422,7 +432,7 @@ export function divorcePocCaseData() {
         id: 'People',
         label: 'Group of People',
         hidden: null,
-        value: null,
+        value: options.peopleValue ?? null,
         metadata: false,
         hint_text: 'Hidden if "Hide all" is entered in Text Field 0; value will not be retained',
         field_type: buildCollectionFieldType({
@@ -434,7 +444,7 @@ export function divorcePocCaseData() {
         order: null,
         formatted_value: null,
         display_context: 'OPTIONAL',
-        display_context_parameter: '#COLLECTION(allowDelete,allowInsert,allowUpdate)',
+        display_context_parameter: peopleDisplayContextParameter,
         show_condition: 'TextField0!="Hide all 4"',
         show_summary_change_option: true,
         show_summary_content_option: null,

--- a/playwright_tests_new/integration/tag-filter.json
+++ b/playwright_tests_new/integration/tag-filter.json
@@ -8,6 +8,7 @@
     "@integration-case-file-view",
     "@integration-case-linking",
     "@integration-case-list",
+    "@integration-ccd-toolkit",
     "@integration-create-case",
     "@integration-data-loss",
     "@integration-hearings",

--- a/playwright_tests_new/integration/test/ccdToolkit/ccdCollectionFieldPermissions.positive.spec.ts
+++ b/playwright_tests_new/integration/test/ccdToolkit/ccdCollectionFieldPermissions.positive.spec.ts
@@ -1,60 +1,11 @@
 import { expect, test } from '../../../E2E/fixtures';
 import { applySessionCookies } from '../../../common/sessionCapture';
-import { TEST_USERS } from '../../testData';
+import { CCD_COLLECTION_FIELD_PERMISSIONS_PEOPLE_VALUE, CCD_COLLECTION_PERMISSION_SCENARIOS, TEST_USERS } from '../../testData';
 import { divorcePocCaseData } from '../../mocks/createCase.mock';
 
 const userIdentifier = TEST_USERS.SOLICITOR;
 const jurisdiction = 'DIVORCE';
 const caseType = 'xuiTestJurisdiction';
-
-const collectionPermissionScenarios = [
-  {
-    displayContextParameter: null,
-    addEnabled: false,
-    removeEnabled: false,
-  },
-  {
-    displayContextParameter: '#COLLECTION(allowInsert,allowDelete)',
-    addEnabled: true,
-    removeEnabled: true,
-  },
-  {
-    displayContextParameter: '#COLLECTION(allowInsert)',
-    addEnabled: true,
-    removeEnabled: false,
-  },
-  {
-    displayContextParameter: '#COLLECTION(allowDelete)',
-    addEnabled: false,
-    removeEnabled: true,
-  },
-  {
-    displayContextParameter: '#TABLE(AddressLine1,AddressLine2),#COLLECTION(allowInsert,allowDelete)',
-    addEnabled: true,
-    removeEnabled: true,
-  },
-  {
-    displayContextParameter: '#COLLECTION()',
-    addEnabled: false,
-    removeEnabled: false,
-  },
-] as const;
-
-const peopleValue = [
-  {
-    id: 'ccd-collection-field-permissions-person',
-    value: {
-      Title: 'Ms',
-      FirstName: 'Ada',
-      LastName: 'Lovelace',
-      PersonGender: 'female',
-      PersonJob: {
-        Title: 'Engineer',
-        Description: 'Builds reliable tests',
-      },
-    },
-  },
-];
 
 test.beforeEach(async ({ page }) => {
   await applySessionCookies(page, userIdentifier);
@@ -66,60 +17,66 @@ test.describe(
     tag: ['@integration', '@integration-create-case', '@integration-ccd-toolkit'],
   },
   () => {
-    for (const scenario of collectionPermissionScenarios) {
+    for (const scenario of CCD_COLLECTION_PERMISSION_SCENARIOS) {
       test(`renders Add and Remove state for ${scenario.displayContextParameter ?? 'null'} display_context_parameter`, async ({
         page,
         createCasePage,
       }) => {
-        await page.route(`**/data/case-types/${caseType}/validate*`, async (route) => {
-          const requestBody = route.request().postDataJSON?.() as { data?: unknown } | undefined;
+        await test.step('Mock create-case routes for the collection display context', async () => {
+          await page.route(`**/data/case-types/${caseType}/validate*`, async (route) => {
+            const requestBody = route.request().postDataJSON?.() as { data?: unknown } | undefined;
 
-          await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify({
-              data: requestBody?.data ?? {},
-              _links: {
-                self: {
-                  href: route.request().url(),
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                data: requestBody?.data ?? {},
+                _links: {
+                  self: {
+                    href: route.request().url(),
+                  },
                 },
-              },
-            }),
+              }),
+            });
+          });
+          await page.route(`**/data/internal/case-types/${caseType}/event-triggers/createCase*`, async (route) => {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify(
+                divorcePocCaseData({
+                  peopleDisplayContextParameter: scenario.displayContextParameter,
+                  peopleValue: CCD_COLLECTION_FIELD_PERMISSIONS_PEOPLE_VALUE,
+                })
+              ),
+            });
           });
         });
-        await page.route(`**/data/internal/case-types/${caseType}/event-triggers/createCase*`, async (route) => {
-          await route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify(
-              divorcePocCaseData({
-                peopleDisplayContextParameter: scenario.displayContextParameter,
-                peopleValue,
-              })
-            ),
-          });
+
+        await test.step('Open the create-case form', async () => {
+          await page.goto(`/cases/case-create/${jurisdiction}/${caseType}/createCase/`);
+          await createCasePage.waitForCreateCaseFormReady('CCD collection permissions setup');
         });
 
-        await page.goto(`/cases/case-create/${jurisdiction}/${caseType}/createCase/`);
-        await createCasePage.waitForCreateCaseFormReady('CCD collection permissions setup');
+        await test.step('Verify collection Add and Remove states', async () => {
+          const addButton = createCasePage.addNewPersonButton.first();
+          const removeButton = createCasePage.additionalPeople.getByRole('button', { name: /Remove/ }).first();
 
-        const addButton = createCasePage.addNewPersonButton.first();
-        const removeButton = createCasePage.additionalPeople.getByRole('button', { name: /Remove/ }).first();
+          await expect(addButton).toBeVisible();
+          await expect(removeButton).toBeVisible();
 
-        await expect(addButton).toBeVisible();
-        await expect(removeButton).toBeVisible();
+          if (scenario.addEnabled) {
+            await expect(addButton).toBeEnabled();
+          } else {
+            await expect(addButton).toBeDisabled();
+          }
 
-        if (scenario.addEnabled) {
-          await expect(addButton).toBeEnabled();
-        } else {
-          await expect(addButton).toBeDisabled();
-        }
-
-        if (scenario.removeEnabled) {
-          await expect(removeButton).toBeEnabled();
-        } else {
-          await expect(removeButton).toBeDisabled();
-        }
+          if (scenario.removeEnabled) {
+            await expect(removeButton).toBeEnabled();
+          } else {
+            await expect(removeButton).toBeDisabled();
+          }
+        });
       });
     }
   }

--- a/playwright_tests_new/integration/test/ccdToolkit/ccdCollectionFieldPermissions.positive.spec.ts
+++ b/playwright_tests_new/integration/test/ccdToolkit/ccdCollectionFieldPermissions.positive.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from '../../../E2E/fixtures';
+import { applySessionCookies } from '../../../common/sessionCapture';
+import { TEST_USERS } from '../../testData';
+import { divorcePocCaseData } from '../../mocks/createCase.mock';
+
+const userIdentifier = TEST_USERS.SOLICITOR;
+const jurisdiction = 'DIVORCE';
+const caseType = 'xuiTestJurisdiction';
+
+const collectionPermissionScenarios = [
+  {
+    displayContextParameter: null,
+    addEnabled: false,
+    removeEnabled: false,
+  },
+  {
+    displayContextParameter: '#COLLECTION(allowInsert,allowDelete)',
+    addEnabled: true,
+    removeEnabled: true,
+  },
+  {
+    displayContextParameter: '#COLLECTION(allowInsert)',
+    addEnabled: true,
+    removeEnabled: false,
+  },
+  {
+    displayContextParameter: '#COLLECTION(allowDelete)',
+    addEnabled: false,
+    removeEnabled: true,
+  },
+  {
+    displayContextParameter: '#TABLE(AddressLine1,AddressLine2),#COLLECTION(allowInsert,allowDelete)',
+    addEnabled: true,
+    removeEnabled: true,
+  },
+  {
+    displayContextParameter: '#COLLECTION()',
+    addEnabled: false,
+    removeEnabled: false,
+  },
+] as const;
+
+const peopleValue = [
+  {
+    id: 'ccd-collection-field-permissions-person',
+    value: {
+      Title: 'Ms',
+      FirstName: 'Ada',
+      LastName: 'Lovelace',
+      PersonGender: 'female',
+      PersonJob: {
+        Title: 'Engineer',
+        Description: 'Builds reliable tests',
+      },
+    },
+  },
+];
+
+test.beforeEach(async ({ page }) => {
+  await applySessionCookies(page, userIdentifier);
+});
+
+test.describe(
+  'CCD toolkit collection field permissions',
+  {
+    tag: ['@integration', '@integration-create-case', '@integration-ccd-toolkit'],
+  },
+  () => {
+    for (const scenario of collectionPermissionScenarios) {
+      test(`renders Add and Remove state for ${scenario.displayContextParameter ?? 'null'} display_context_parameter`, async ({
+        page,
+        createCasePage,
+      }) => {
+        await page.route(`**/data/case-types/${caseType}/validate*`, async (route) => {
+          const requestBody = route.request().postDataJSON?.() as { data?: unknown } | undefined;
+
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              data: requestBody?.data ?? {},
+              _links: {
+                self: {
+                  href: route.request().url(),
+                },
+              },
+            }),
+          });
+        });
+        await page.route(`**/data/internal/case-types/${caseType}/event-triggers/createCase*`, async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(
+              divorcePocCaseData({
+                peopleDisplayContextParameter: scenario.displayContextParameter,
+                peopleValue,
+              })
+            ),
+          });
+        });
+
+        await page.goto(`/cases/case-create/${jurisdiction}/${caseType}/createCase/`);
+        await createCasePage.waitForCreateCaseFormReady('CCD collection permissions setup');
+
+        const addButton = createCasePage.addNewPersonButton.first();
+        const removeButton = createCasePage.additionalPeople.getByRole('button', { name: /Remove/ }).first();
+
+        await expect(addButton).toBeVisible();
+        await expect(removeButton).toBeVisible();
+
+        if (scenario.addEnabled) {
+          await expect(addButton).toBeEnabled();
+        } else {
+          await expect(addButton).toBeDisabled();
+        }
+
+        if (scenario.removeEnabled) {
+          await expect(removeButton).toBeEnabled();
+        } else {
+          await expect(removeButton).toBeDisabled();
+        }
+      });
+    }
+  }
+);

--- a/playwright_tests_new/integration/testData/ccdCollectionFieldPermissionsScenarios.ts
+++ b/playwright_tests_new/integration/testData/ccdCollectionFieldPermissionsScenarios.ts
@@ -1,0 +1,48 @@
+export const CCD_COLLECTION_PERMISSION_SCENARIOS = [
+  {
+    displayContextParameter: null,
+    addEnabled: false,
+    removeEnabled: false,
+  },
+  {
+    displayContextParameter: '#COLLECTION(allowInsert,allowDelete)',
+    addEnabled: true,
+    removeEnabled: true,
+  },
+  {
+    displayContextParameter: '#COLLECTION(allowInsert)',
+    addEnabled: true,
+    removeEnabled: false,
+  },
+  {
+    displayContextParameter: '#COLLECTION(allowDelete)',
+    addEnabled: false,
+    removeEnabled: true,
+  },
+  {
+    displayContextParameter: '#TABLE(AddressLine1,AddressLine2),#COLLECTION(allowInsert,allowDelete)',
+    addEnabled: true,
+    removeEnabled: true,
+  },
+  {
+    displayContextParameter: '#COLLECTION()',
+    addEnabled: false,
+    removeEnabled: false,
+  },
+] as const;
+
+export const CCD_COLLECTION_FIELD_PERMISSIONS_PEOPLE_VALUE = [
+  {
+    id: 'ccd-collection-field-permissions-person',
+    value: {
+      Title: 'Ms',
+      FirstName: 'Ada',
+      LastName: 'Lovelace',
+      PersonGender: 'female',
+      PersonJob: {
+        Title: 'Engineer',
+        Description: 'Builds reliable tests',
+      },
+    },
+  },
+];

--- a/playwright_tests_new/integration/testData/index.ts
+++ b/playwright_tests_new/integration/testData/index.ts
@@ -12,3 +12,4 @@ export * from './caseReferences';
 export * from './searchCaseNegativeScenarios';
 export * from './taskListScenarios';
 export * from './caseListNegativeScenarios.ts';
+export * from './ccdCollectionFieldPermissionsScenarios';


### PR DESCRIPTION
### Jira link

See [EXUI-4514](https://tools.hmcts.net/jira/browse/EXUI-4514)

### Change description

Adds focused CCD toolkit integration coverage for collection field add/remove permissions.

This PR adds an `@integration-ccd-toolkit` tag, wires the targeted session warmup to the solicitor user, extends the create-case mock for collection permission variants, and adds a positive spec covering Add and Remove button states for the People collection field.

### Value added

This adds direct regression coverage for CCD collection field permission handling, specifically the `display_context_parameter` combinations that control whether users can add or remove collection rows.

The test pack now proves the UI state for null permissions, insert/delete together, insert only, delete only, table metadata combined with collection permissions, and an empty collection permission directive. That gives us coverage of the real matrix rather than a single happy path.

The value is practical: collection permission regressions are user-facing and easy to miss because the page can render while one action is incorrectly enabled or disabled. These tests make that behaviour explicit and catch failures where a user could be blocked from adding required collection data or incorrectly allowed to remove data when the field contract should prevent it.

The session warmup unit coverage also means targeted `@integration-ccd-toolkit` runs should start with the right solicitor session, reducing false failures when the new pack is run in isolation.

### Dependency PRs

None.

### Testing done

- `yarn lint:prettier playwright_tests_new/integration/test/ccdToolkit/ccdCollectionFieldPermissions.positive.spec.ts playwright_tests_new/integration/tag-filter.json playwright_tests_new/integration/mocks/createCase.mock.ts playwright_tests_new/integration/helpers/searchCaseSession.helper.ts playwright_tests_new/api/unit/search-case-session.unit.api.ts`
- `yarn test:api:pw -- playwright_tests_new/api/unit/search-case-session.unit.api.ts`
- `PLAYWRIGHT_SKIP_INSTALL=true PLAYWRIGHT_REPORTERS=list,html yarn test:playwright:integration -- playwright_tests_new/integration/test/ccdToolkit/ccdCollectionFieldPermissions.positive.spec.ts`
- `git diff --check origin/master...HEAD`

Focused unit result: 10 passed, 0 flaky.
Focused integration result: 6 passed, 0 flaky.

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
