### PR TITLE
EXUI-4927 Harden case flags E2E empty state

### DIFF
--- a/playwright_tests_new/E2E/page-objects/pages/exui/caseDetails.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/caseDetails.po.ts
@@ -57,8 +57,9 @@ export class CaseDetailsPage extends Base {
   readonly tabList = this.page.locator('div[role="tablist"]');
   readonly tablist2 = this.page.getByRole('tab');
 
-  //Case flags
   // Case flags
+  readonly caseFlagsHeading = this.page.getByRole('heading', { name: 'Case flags', exact: true });
+
   readonly caseFlagCommentBox = this.page.locator('#flagComments');
 
   readonly caseFlagApplicantFlagTable = this.page.locator('table.govuk-table.ng-star-inserted');

--- a/playwright_tests_new/E2E/test/caseFlags/caseFlags.positive.spec.ts
+++ b/playwright_tests_new/E2E/test/caseFlags/caseFlags.positive.spec.ts
@@ -62,12 +62,9 @@ test.describe('Case level case flags', { tag: ['@e2e', '@e2e-case-flags'] }, () 
   });
 
   test('Create a new case level flag and verify the flag is displayed on the case', async ({ caseDetailsPage, tableUtils }) => {
-    await test.step('Record existing case level flags', async () => {
+    await test.step('Open case flags tab', async () => {
       await caseDetailsPage.selectCaseDetailsTab('Flags');
-      const flagsTable = await caseDetailsPage.waitForTableByName('Case level flags');
-      const table = await tableUtils.parseDataTable(flagsTable);
-      const visibleRows = filterEmptyRows(table);
-      expect.soft(visibleRows.length).toBeGreaterThanOrEqual(0);
+      await expect(caseDetailsPage.caseFlagsHeading).toBeVisible();
     });
 
     await test.step('Create a new case level flag', async () => {


### PR DESCRIPTION
### Jira link

See [EXUI-4927](https://tools.hmcts.net/jira/browse/EXUI-4927)

### Change description

Harden the case-flags E2E that failed on PR 5279 when the Employment Case Flags tab opened with no case-level flags yet.

The scenario was waiting for the `Case level flags` table before creating the first case-level flag. In the failing UI state the Case Flags tab was loaded correctly, party-level flag sections were visible, and no downstream/API dominant failure was captured, but the case-level table was not rendered in the empty state. The test now waits for the Case Flags page heading as the pre-create readiness signal, then still validates the `Case level flags` table after the new flag is created.

The PR 5279 branch comparison showed only `package.json` and `yarn.lock` changes for the `compression` dependency, with no relevant changes in the case-flags test, page object, or Employment case setup. This is a test contract hardening fix rather than a product/API fix.

### Dependency PRs

None.

### Testing done

- `yarn install --immutable` - passed with existing warnings.
- `yarn npm audit --recursive --environment production --json > yarn-audit-known-issues` - exited 1 with 14 valid JSON-lines for existing advisories; `yarn-audit-known-issues` had no diff.
- `yarn lint` - passed with 0 errors and the existing warning set.
- `git diff --check` - passed.
- Focused reproduction before the fix against the PR 5279 preview failed on all three attempts with retries disabled.
- Focused proof after the fix against the PR 5279 preview passed three times with `PW_E2E_RETRIES=0`.

Evidence:
- `functional-output/tests/case-flags-repro-1/odhin-report/xui-case-flags-repro-1.html`
- `functional-output/tests/case-flags-fix-1/odhin-report/xui-case-flags-fix-1.html`
- `functional-output/tests/case-flags-fix-2/odhin-report/xui-case-flags-fix-2.html`
- `functional-output/tests/case-flags-fix-3/odhin-report/xui-case-flags-fix-3.html`

Branch-local rerun on `EXUI-4927-case-flags-empty-state` did not reach the changed lines because local IDAM session capture failed for `SEARCH_EMPLOYMENT_CASE` before the test body started. Trace/report retained for the environment blocker:
- `test-results/test-caseFlags-caseFlags.p-011cb-ag-is-displayed-on-the-case-chromium/trace.zip`
- `functional-output/tests/case-flags-exui-4927-rerun/odhin-report/xui-case-flags-exui-4927-rerun.html`

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
