### PR TITLE
EXUI-4930 Harden Find Case E2E timeout diagnostics

### DIFF
--- a/playwright_tests_new/E2E/page-objects/pages/exui/findCase.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/findCase.po.ts
@@ -139,7 +139,7 @@ export class FindCasePage extends Base {
     const caseDetailsLink = this.searchResultsTable
       .locator(`a.govuk-link[href*="/cases/case-details/"][href*="${normalizedCaseNumber}"]`)
       .first();
-    await caseDetailsLink.waitFor({ state: 'visible', timeout: EXUI_TIMEOUTS.SEARCH_SPINNER_RESULT_HIDDEN });
+    await this.waitForMatchingCaseResult(caseDetailsLink, normalizedCaseNumber);
     await this.openCaseDetailsFromSearchResult(caseDetailsLink, normalizedCaseNumber, caseNumber);
   }
 
@@ -198,8 +198,8 @@ export class FindCasePage extends Base {
     originalCaseNumber: string
   ): Promise<void> {
     for (let attemptIndex = 0; attemptIndex < MAX_NAVIGATION_RETRY_ATTEMPTS; attemptIndex++) {
-      await searchResultCaseLink.scrollIntoViewIfNeeded();
-      await searchResultCaseLink.click();
+      await searchResultCaseLink.scrollIntoViewIfNeeded({ timeout: EXUI_TIMEOUTS.WAIT_FOR_SELECT_READY_DEFAULT });
+      await searchResultCaseLink.click({ timeout: EXUI_TIMEOUTS.SEARCH_BUTTON_CLICK });
       await this.exuiSpinnerComponent.wait();
       if (await this.waitForCaseDetailsUrl(caseNumberFromUrl, EXUI_TIMEOUTS.CASE_DETAILS_NAVIGATION)) {
         return;
@@ -217,6 +217,25 @@ export class FindCasePage extends Base {
       return true;
     } catch {
       return false;
+    }
+  }
+
+  private async waitForMatchingCaseResult(caseDetailsLink: Locator, caseNumber: string): Promise<void> {
+    try {
+      await caseDetailsLink.waitFor({ state: 'visible', timeout: EXUI_TIMEOUTS.SEARCH_SPINNER_RESULT_HIDDEN });
+    } catch {
+      const resultsText = ((await this.searchResultsContainer.textContent().catch(() => '')) ?? '').trim();
+      const visibleCaseReferences = await this.searchResultsTable
+        .locator('a.govuk-link[href*="/cases/case-details/"]')
+        .evaluateAll((links) => links.map((link) => link.textContent?.replace(/\D/g, '') ?? '').filter(Boolean))
+        .catch(() => []);
+      const visibleReferencesMessage = visibleCaseReferences.length
+        ? ` Visible case references: ${visibleCaseReferences.join(', ')}.`
+        : '';
+
+      throw new Error(
+        `Find Case results did not contain case reference ${caseNumber} within ${EXUI_TIMEOUTS.SEARCH_SPINNER_RESULT_HIDDEN}ms. Results text: ${resultsText || '<empty>'}.${visibleReferencesMessage}`
+      );
     }
   }
 


### PR DESCRIPTION
### Jira link

See [EXUI-4930](https://tools.hmcts.net/jira/browse/EXUI-4930)

### Change description

- Harden the Find Case E2E page object so it proves the searched case-details link is present before scrolling/clicking it.
- Add a targeted diagnostic error when AAT search results do not contain the expected case reference, including result-panel text and visible case references where available.
- Bound the result-link scroll and click actions with existing timeout constants so a missing locator does not consume the full 180-second test timeout.

### Dependency PRs

N/A

### Testing done

Automated:

- [x] `yarn prettier -c playwright_tests_new/E2E/page-objects/pages/exui/findCase.po.ts`
- [x] `node ./node_modules/eslint/bin/eslint.js playwright_tests_new/E2E/page-objects/pages/exui/findCase.po.ts`
- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:playwright:integration -- --grep "User can find an existing case from Find case filters"`
- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:playwrightE2E -- --grep "Find case using Public Law jurisdiction"`
- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:playwrightE2E -- --grep "Find case using Public Law jurisdiction" --repeat-each=3`
- [x] `yarn npm audit --recursive --environment production --json > yarn-audit-known-issues` exited `1` as expected with advisories; output validated as 14 JSON lines and produced no file diff.

Manual:

- [x] Confirmed Jira ticket was created from EXUI-4927 field shape.
- [x] Confirmed Jenkins CLI jar endpoint is AAD-gated; Jenkins build URL and captured timeout signature are recorded in EXUI-4930.

Evidence:

- HTML: N/A
- Odhin: generated by focused Playwright runs under `test-results/` lightweight output
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
