### PR TITLE
EXUI-4968: stabilise update case spinner handling

### DIFF
--- a/playwright_tests_new/E2E/page-objects/pages/exui/caseDetails.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/caseDetails.po.ts
@@ -504,6 +504,8 @@ export class CaseDetailsPage extends Base {
         `Case action "${action}" is not available. Available actions: ${availableOptions.map((option) => option.label || option.value).join(', ')}`
       );
     }
+    const timeoutMs = options.timeoutMs ?? 30000;
+    await this.waitForSpinnerToComplete(`before selecting case action "${action}"`, timeoutMs);
     try {
       if (matchingOption.label === action) {
         await this.caseActionsDropdown.selectOption({ label: action });
@@ -515,13 +517,13 @@ export class CaseDetailsPage extends Base {
       this.logger.warn('Failed to select option by label, falling back to value selector', { error });
       await this.caseActionsDropdown.selectOption(matchingOption.value || action);
     }
+    await this.waitForSpinnerToComplete(`before submitting case action "${action}"`, timeoutMs);
     await this.caseActionGoButton.click();
     await this.waitForSpinnerToComplete('after selecting case action');
     await this.page.waitForLoadState('domcontentloaded');
     if (!options.expectedLocator && !options.expectedPath) {
       return;
     }
-    const timeoutMs = options.timeoutMs ?? 30000;
     const waitForExpected = async () => {
       if (options.expectedPath) {
         const matcher =
@@ -553,6 +555,7 @@ export class CaseDetailsPage extends Base {
         this.logger.warn('Retry: failed to select option by label, falling back to value selector', { retryError });
         await this.caseActionsDropdown.selectOption(matchingOption.value || action);
       }
+      await this.waitForSpinnerToComplete(`before retrying case action "${action}"`, timeoutMs);
       await this.caseActionGoButton.click();
       await this.waitForSpinnerToComplete('after retrying case action');
       await this.page.waitForLoadState('domcontentloaded');

--- a/playwright_tests_new/E2E/page-objects/pages/exui/caseDetails.po.ts
+++ b/playwright_tests_new/E2E/page-objects/pages/exui/caseDetails.po.ts
@@ -565,12 +565,35 @@ export class CaseDetailsPage extends Base {
 
   private async waitForSpinnerToComplete(context: string, timeoutMs?: number) {
     const effectiveTimeoutMs = timeoutMs ?? this.getRecommendedTimeoutMs();
-    const spinner = this.page.locator('xuilib-loading-spinner').first();
     try {
-      await spinner.waitFor({ state: 'hidden', timeout: effectiveTimeoutMs });
+      await this.page.waitForFunction(
+        () => {
+          const spinners = Array.from(
+            document.querySelectorAll<HTMLElement>('xuilib-loading-spinner, xuilib-loading-spinner .spinner-container')
+          );
+          return spinners.every((spinner) => {
+            const style = window.getComputedStyle(spinner);
+            const bounds = spinner.getBoundingClientRect();
+            return style.display === 'none' || style.visibility === 'hidden' || bounds.width === 0 || bounds.height === 0;
+          });
+        },
+        undefined,
+        { timeout: effectiveTimeoutMs }
+      );
     } catch (error) {
-      const stillVisible = await spinner.isVisible().catch(() => false);
-      if (stillVisible) {
+      const visibleSpinnerCount = await this.page
+        .locator('xuilib-loading-spinner, xuilib-loading-spinner .spinner-container')
+        .evaluateAll(
+          (spinners) =>
+            spinners.filter((spinner) => {
+              const element = spinner as HTMLElement;
+              const style = window.getComputedStyle(element);
+              const bounds = element.getBoundingClientRect();
+              return style.display !== 'none' && style.visibility !== 'hidden' && bounds.width > 0 && bounds.height > 0;
+            }).length
+        )
+        .catch(() => 0);
+      if (visibleSpinnerCount > 0) {
         throw new Error(`Spinner still visible ${context}`);
       }
       this.logger.warn('Spinner hidden wait failed, proceeding because spinner not visible', { context, error });

--- a/playwright_tests_new/E2E/test/updateCase/updateCase.spec.ts
+++ b/playwright_tests_new/E2E/test/updateCase/updateCase.spec.ts
@@ -48,6 +48,7 @@ test.describe('Verify creating and updating a case works as expected', { tag: ['
       await caseDetailsPage.selectCaseAction('Update case', {
         expectedLocator: createCasePage.person2FirstNameInput,
         timeoutMs: UPDATE_CASE_ACTION_TIMEOUT_MS,
+        retry: false,
       });
     });
 

--- a/playwright_tests_new/api/unit/case-action-selection.unit.api.ts
+++ b/playwright_tests_new/api/unit/case-action-selection.unit.api.ts
@@ -60,4 +60,48 @@ test.describe('Case action selection', { tag: '@svc-internal' }, () => {
       'wait-for-expected',
     ]);
   });
+
+  test('does not retry the selected action when retry is disabled', async () => {
+    let clickCount = 0;
+    const expectedLocator = {
+      toString: () => 'getByLabel(First name)',
+      waitFor: async () => {
+        throw new Error('event page did not load');
+      },
+    };
+    const pageObject = {
+      caseActionGoButton: {
+        waitFor: async () => undefined,
+        click: async () => {
+          clickCount += 1;
+        },
+      },
+      caseActionsDropdown: {
+        waitFor: async () => undefined,
+        locator: () => ({
+          evaluateAll: async () => [{ label: 'Update case', value: 'updateCase' }],
+        }),
+        selectOption: async () => undefined,
+      },
+      eventCreationErrorHeading: {
+        isVisible: async () => false,
+      },
+      logger: {
+        warn: () => undefined,
+      },
+      page: {
+        waitForLoadState: async () => undefined,
+      },
+      waitForSpinnerToComplete: async () => undefined,
+    } as unknown as CaseDetailsPage;
+
+    await expect(
+      CaseDetailsPage.prototype.selectCaseAction.call(pageObject, 'Update case', {
+        expectedLocator: expectedLocator as unknown as Locator,
+        retry: false,
+      })
+    ).rejects.toThrow('event page did not load');
+
+    expect(clickCount).toBe(1);
+  });
 });

--- a/playwright_tests_new/api/unit/case-action-selection.unit.api.ts
+++ b/playwright_tests_new/api/unit/case-action-selection.unit.api.ts
@@ -1,0 +1,63 @@
+import { expect, test, type Locator } from '@playwright/test';
+
+import { CaseDetailsPage } from '../../E2E/page-objects/pages/exui/caseDetails.po.js';
+
+test.describe('Case action selection', { tag: '@svc-internal' }, () => {
+  test('waits for the loading spinner before submitting the selected action', async () => {
+    let clickCount = 0;
+    const actionSequence: string[] = [];
+    const expectedLocator = {
+      toString: () => 'getByLabel(First name)',
+      waitFor: async () => {
+        actionSequence.push('wait-for-expected');
+      },
+    };
+    const pageObject = {
+      caseActionGoButton: {
+        waitFor: async () => undefined,
+        click: async () => {
+          actionSequence.push('click-go');
+          clickCount += 1;
+        },
+      },
+      caseActionsDropdown: {
+        waitFor: async () => undefined,
+        locator: () => ({
+          evaluateAll: async () => [{ label: 'Update case', value: 'updateCase' }],
+        }),
+        selectOption: async () => {
+          actionSequence.push('select-option');
+        },
+      },
+      eventCreationErrorHeading: {
+        isVisible: async () => false,
+      },
+      logger: {
+        warn: () => undefined,
+      },
+      page: {
+        waitForLoadState: async () => undefined,
+      },
+      waitForSpinnerToComplete: async (context: string) => {
+        actionSequence.push(context);
+      },
+    } as unknown as CaseDetailsPage;
+
+    const attempt = CaseDetailsPage.prototype.selectCaseAction.call(pageObject, 'Update case', {
+      expectedLocator: expectedLocator as unknown as Locator,
+      retry: false,
+    });
+
+    await expect(attempt).resolves.toBeUndefined();
+
+    expect(clickCount).toBe(1);
+    expect(actionSequence).toEqual([
+      'before selecting case action "Update case"',
+      'select-option',
+      'before submitting case action "Update case"',
+      'click-go',
+      'after selecting case action',
+      'wait-for-expected',
+    ]);
+  });
+});


### PR DESCRIPTION
### Jira link

See [EXUI-4968](https://tools.hmcts.net/jira/browse/EXUI-4968)

### Change description

- Stabilise case-action submission in E2E flows by waiting for the XUI loading spinner before clicking the selected action `Go` button.
- Add focused API/unit coverage proving `selectCaseAction()` waits before selecting and before clicking.

### Dependency PRs

N/A

### Testing done

Automated:

- [x] `PLAYWRIGHT_SKIP_INSTALL=true yarn test:api:pw:raw -- playwright_tests_new/api/unit/case-action-selection.unit.api.ts --project node-api`
- [x] `node ./node_modules/prettier/bin/prettier.cjs -c playwright_tests_new/E2E/page-objects/pages/exui/caseDetails.po.ts playwright_tests_new/api/unit/case-action-selection.unit.api.ts`

Manual:

- [ ] Not run: live AAT update-case E2E requires Jenkins/AAT runtime credentials and environment stability.

Evidence:

- HTML: N/A
- Odhin: `functional-output/tests/playwright-api/odhin-report/xui-playwright-api.html`
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
