### PR TITLE
exui-4970-jenkin upgrade

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -70,7 +70,7 @@ properties([
 
 // use Infrastructure branch in PR for long running FT's beyond 40mins for DEBUG only
 // @Library("Infrastructure@fpl-long-ft-timeout")
-@Library("Infrastructure@2.0.0")
+@Library("Infrastructure@2.4.5")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/EXUI-4970

### Change description
jenkin upgrade to 2.4.5