### PR TITLE
EXUI-2645(fix) - Add quick fix to edit functionality to work as previously

### DIFF
--- a/api/workAllocation/index.spec.ts
+++ b/api/workAllocation/index.spec.ts
@@ -1572,6 +1572,20 @@ describe('workAllocation', () => {
       expect(response.send).to.have.been.calledWith(refinedCaseworker);
     });
 
+    it('returns null with 200 for silent not found', async () => {
+      FullUserDetailCache.setUserDetails([]);
+      sandbox.stub(caseWorkerUserDataCacheService, 'timestampExists').returns(true);
+
+      const req = mockReq({
+        body: { idamId: 'judicial-user', silentNotFound: true },
+        session: { passport: { user: { userinfo: { roles: ['caseworker-role'] } } } },
+      });
+      const response = mockRes();
+      await getUserByIdamId(req, response, next);
+      expect(response.status).to.have.been.calledWith(200);
+      expect(response.send).to.have.been.calledWith(null);
+    });
+
     it('refreshes cache and returns user when firstEntry', async () => {
       FullUserDetailCache.setUserDetails([]);
       sandbox.stub(caseWorkerUserDataCacheService, 'timestampExists').returns(false);

--- a/api/workAllocation/index.ts
+++ b/api/workAllocation/index.ts
@@ -727,6 +727,7 @@ export async function getUserByIdamId(req: EnhancedRequest, res: Response, next:
   try {
     const currentUser: UserInfo = req.session.passport.user.userinfo;
     const idamId = req.body.idamId;
+    const silentNotFound = req.body.silentNotFound;
     let idamUser = null;
     let firstEntry = true;
     if (currentUser.roles?.includes(PUI_CASE_MANAGER)) {
@@ -738,6 +739,10 @@ export async function getUserByIdamId(req: EnhancedRequest, res: Response, next:
         firstEntry = false;
         idamUser = FullUserDetailCache.getUserByIdamId(idamId);
         if (!idamUser) {
+          if (silentNotFound) {
+            res.status(200).send(null);
+            return;
+          }
           res.status(404).send('User not found');
           return;
         } else {
@@ -755,6 +760,10 @@ export async function getUserByIdamId(req: EnhancedRequest, res: Response, next:
         // note: this is now only a safeguard to ensure caching (caching should have run pre login)
         idamUser = FullUserDetailCache.getUserByIdamId(idamId);
         if (!idamUser) {
+          if (silentNotFound) {
+            res.status(200).send(null);
+            return;
+          }
           res.status(404).send('User not found');
           return;
         } else {

--- a/src/work-allocation/resolvers/task.resolver.spec.ts
+++ b/src/work-allocation/resolvers/task.resolver.spec.ts
@@ -1,7 +1,7 @@
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { Caseworker } from '../models/dtos';
-import { getAssignedMockTask, getMockTasks } from '../tests/utils.spec';
+import { getAssignedMockTask } from '../tests/utils.spec';
 import { TaskResolver } from './task.resolver';
 
 describe('Task Resolver', () => {
@@ -24,6 +24,52 @@ describe('Task Resolver', () => {
       expect(taskCaseWorker.task.task).toEqual(getAssignedMockTask());
       expect(taskCaseWorker.caseworker).toEqual({} as Caseworker);
       expect(mockService.getTask).toHaveBeenCalledWith('somevalue');
+      expect(mockCaseWorkerService.getUserByIdamId).toHaveBeenCalledWith(getAssignedMockTask().assignee, true);
+    });
+  });
+
+  it('returns null caseworker when getUserByIdamId returns 404', () => {
+    const mockService = jasmine.createSpyObj('WorkAllocationTaskService', ['getTask']);
+    const mockCaseWorkerService = jasmine.createSpyObj('CaseworkerDataService', ['getUserByIdamId']);
+    mockService.getTask.and.returnValue(of({ task: getAssignedMockTask() }));
+    mockCaseWorkerService.getUserByIdamId.and.returnValue(throwError({ status: 404 }));
+    const mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    const taskResolver = new TaskResolver(mockService, mockRouter, mockCaseWorkerService);
+    const route = jasmine.createSpyObj('Route', ['']);
+    route.paramMap = {
+      get: () => {
+        return 'somevalue';
+      },
+    };
+
+    const taskCaseWorker$ = taskResolver.resolve(route);
+    taskCaseWorker$.subscribe((taskCaseWorker) => {
+      expect(taskCaseWorker.task.task).toEqual(getAssignedMockTask());
+      expect(taskCaseWorker.caseworker).toBeNull();
+      expect(mockCaseWorkerService.getUserByIdamId).toHaveBeenCalledWith(getAssignedMockTask().assignee, true);
+    });
+  });
+
+  it('does not suppress non-404 getUserByIdamId errors', () => {
+    const mockService = jasmine.createSpyObj('WorkAllocationTaskService', ['getTask']);
+    const mockCaseWorkerService = jasmine.createSpyObj('CaseworkerDataService', ['getUserByIdamId']);
+    mockService.getTask.and.returnValue(of({ task: getAssignedMockTask() }));
+    mockCaseWorkerService.getUserByIdamId.and.returnValue(throwError({ status: 500 }));
+    const mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    const taskResolver = new TaskResolver(mockService, mockRouter, mockCaseWorkerService);
+    const route = jasmine.createSpyObj('Route', ['']);
+    route.paramMap = {
+      get: () => {
+        return 'somevalue';
+      },
+    };
+
+    const taskCaseWorker$ = taskResolver.resolve(route);
+    taskCaseWorker$.subscribe({
+      error: (error) => {
+        expect(error.status).toEqual(500);
+        expect(mockCaseWorkerService.getUserByIdamId).toHaveBeenCalledWith(getAssignedMockTask().assignee, true);
+      },
     });
   });
 });

--- a/src/work-allocation/resolvers/task.resolver.ts
+++ b/src/work-allocation/resolvers/task.resolver.ts
@@ -29,7 +29,14 @@ export class TaskResolver {
           // if no assignee, return no caseworker
           return of(null);
         }
-        return this.caseworkerService.getUserByIdamId(task.task.assignee);
+        return this.caseworkerService.getUserByIdamId(task.task.assignee, true).pipe(
+          catchError((error) => {
+            if (error.status === 404) {
+              return of(null);
+            }
+            throw error;
+          })
+        );
       })
     );
     return forkJoin({ task: task$, caseworker: caseworker$ });

--- a/src/work-allocation/services/caseworker-data.service.spec.ts
+++ b/src/work-allocation/services/caseworker-data.service.spec.ts
@@ -39,5 +39,23 @@ describe('WorkAllocation service', () => {
       service.getDetails('123456');
       expect(mockHttpService.get).toHaveBeenCalledWith(`${CaseworkerDataService.caseWorkerUrl}/123456`);
     });
+
+    it('getUserByIdamId should make correct api call', () => {
+      const service = new CaseworkerDataService(mockHttpService);
+      service.getUserByIdamId('123456');
+      expect(mockHttpService.post).toHaveBeenCalledWith(`${CaseworkerDataService.caseWorkerUrl}/getUserByIdamId`, {
+        idamId: '123456',
+        silentNotFound: false,
+      });
+    });
+
+    it('getUserByIdamId should support silent not found', () => {
+      const service = new CaseworkerDataService(mockHttpService);
+      service.getUserByIdamId('123456', true);
+      expect(mockHttpService.post).toHaveBeenCalledWith(`${CaseworkerDataService.caseWorkerUrl}/getUserByIdamId`, {
+        idamId: '123456',
+        silentNotFound: true,
+      });
+    });
   });
 });

--- a/src/work-allocation/services/caseworker-data.service.ts
+++ b/src/work-allocation/services/caseworker-data.service.ts
@@ -33,7 +33,7 @@ export class CaseworkerDataService {
     return this.http.post<Caseworker[]>(`${CaseworkerDataService.caseWorkerUrl}/getUsersByIdamIds`, { idamIds, services });
   }
 
-  public getUserByIdamId(idamId: string): Observable<Caseworker> {
-    return this.http.post<Caseworker>(`${CaseworkerDataService.caseWorkerUrl}/getUserByIdamId`, { idamId });
+  public getUserByIdamId(idamId: string, silentNotFound = false): Observable<Caseworker> {
+    return this.http.post<Caseworker>(`${CaseworkerDataService.caseWorkerUrl}/getUserByIdamId`, { idamId, silentNotFound });
   }
 }


### PR DESCRIPTION
If user not found in caseworkers, return null, this will then be searched in judicial users

Previous functionality was return all caseworkers and if user not present then search judicial users

### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2645

### Change description

Ensure that judicial users can correctly reassign/cancel/complete

### Testing done

Ensured task reassignment/cancelling/completing works for judicial and non-judicial users

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [ x ] No
