### PR TITLE
Adding probate case types to demo

### DIFF
--- a/src/app/services/ccd-config/launch-darkly-defaults.constants.ts
+++ b/src/app/services/ccd-config/launch-darkly-defaults.constants.ts
@@ -243,6 +243,7 @@ export class LaunchDarklyDefaultsConstants {
       ],
       "releaseVersion": "4",
        "serviceName": "PROBATE"
+    }
     ]
   }`;
 

--- a/src/app/services/ccd-config/launch-darkly-defaults.constants.ts
+++ b/src/app/services/ccd-config/launch-darkly-defaults.constants.ts
@@ -233,7 +233,16 @@ export class LaunchDarklyDefaultsConstants {
       ],
       "releaseVersion": "4",
       "serviceName": "PCS"
-    }
+    },
+    {
+      "caseTypes": [
+        "GrantOfRepresentation",
+        "Caveat",
+        "StandingSearch",
+        "WillLodgement"
+      ],
+      "releaseVersion": "4",
+       "serviceName": "PROBATE"
     ]
   }`;
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/COT-1276

### Change description

Probate are starting testing in demo.  work allocation and global search have been enabled via flux, but launch-darkly-defaults needs updated to add the probate caseTypes to the demo configuration.  This will allow the tasks and roles and access tabs to be displayed in demo. 

### Dependency PRs


### Testing done

This configuration has been tested in the probate pr environment.  This pr is to apply the change to the WASERVICECONFIGTESTQM, which is used in the demo environment. 

### Security Vulnerability Assessment


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
- [x] Can this PR be released on a Friday (ie: no functional code changes)
