### PR TITLE
Fix API exclusion tag validation

### DIFF
--- a/playwright_tests_new/api/playwright-config-coverage.api.ts
+++ b/playwright_tests_new/api/playwright-config-coverage.api.ts
@@ -382,6 +382,17 @@ test.describe('Playwright config coverage', { tag: '@svc-internal' }, () => {
     expect(filters.grepInvert).toBeUndefined();
   });
 
+  test('node-api can exclude only the unstable Work Allocation myaccess check', () => {
+    const filters = resolveApiTagFilters({
+      PLAYWRIGHT_GLOBAL_EXCLUDED_TAGS: '@svc-work-allocation-myaccess',
+      CI: undefined,
+    });
+
+    expect(filters.excludedTags).toEqual(['@svc-work-allocation-myaccess']);
+    expect(filters.grepInvert?.test('@svc-work-allocation-myaccess')).toBe(true);
+    expect(filters.grepInvert?.test('@svc-work-allocation')).toBe(false);
+  });
+
   test('node-api treats @none as the global Key Vault no-op sentinel', () => {
     const filters = resolveApiTagFilters({
       PLAYWRIGHT_GLOBAL_EXCLUDED_TAGS: '@none',

--- a/playwright_tests_new/api/service-tag-filter.json
+++ b/playwright_tests_new/api/service-tag-filter.json
@@ -13,6 +13,7 @@
     "@svc-ref-data",
     "@svc-role-assignment",
     "@svc-work-allocation",
+    "@svc-work-allocation-myaccess",
     "@svc-internal"
   ]
 }

--- a/playwright_tests_new/api/work-allocation.api.ts
+++ b/playwright_tests_new/api/work-allocation.api.ts
@@ -278,7 +278,8 @@ test.describe('Work allocation (read-only)', { tag: '@svc-work-allocation' }, ()
   test.describe('my-work dashboards', () => {
     const endpoints = ['workallocation/my-work/cases', 'workallocation/my-work/myaccess'];
     for (const endpoint of endpoints) {
-      test(`${endpoint} returns data or guarded status`, async ({ apiClient }) => {
+      const tags = endpoint.endsWith('/myaccess') ? ['@svc-work-allocation-myaccess'] : [];
+      test(`${endpoint} returns data or guarded status`, { tag: tags }, async ({ apiClient }) => {
         const response = await withXsrf('solicitor', (headers) =>
           guardedRequest(() =>
             apiClient.get(endpoint, {


### PR DESCRIPTION
## Summary

- register the Key Vault exclusion tag used by Jenkins
- apply it only to the unstable Work Allocation `myaccess` API check
- add a configuration regression test

## Evidence

- `yarn lint:prettier` passed
- focused config regression: 1 passed
- AAT Work Allocation API suite with the production exclusion: 71 passed in 13.5 seconds

## Full-suite follow-up

The whole local API suite begins authenticated AAT execution but the Codex command window terminates it before completion. The PR Jenkins API lane is required for the complete suite result.

## AI assistance

AI-assisted diagnosis and implementation; human review required before merge.
