### PR TITLE
fix: keep nightly accessibility failures non-blocking

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -128,7 +128,7 @@ def publishPlaywrightAccessibilityJUnit = {
         return
     }
     try {
-        junit allowEmptyResults: false, testResults: playwrightAccessibilityJunitFile
+        junit allowEmptyResults: false, skipMarkingBuildUnstable: true, testResults: playwrightAccessibilityJunitFile
     } catch (Exception e) {
         if (e instanceof org.jenkinsci.plugins.workflow.steps.FlowInterruptedException) {
             throw e

--- a/playwright_tests_new/api/unit/jenkins-playwright-reporting.unit.api.ts
+++ b/playwright_tests_new/api/unit/jenkins-playwright-reporting.unit.api.ts
@@ -111,6 +111,7 @@ test.describe('Jenkins Playwright report publication', { tag: '@svc-internal' },
     expect(nightlySource).toContain("outcome = runnerCompleted ? 'completed' : 'test-failure'");
     expect(nightlySource).toContain('def publishPlaywrightAccessibilityJUnit = {');
     expect(nightlySource).toContain('if (!fileExists(playwrightAccessibilityJunitFile))');
+    expect(nightlySource).toContain('skipMarkingBuildUnstable: true, testResults: playwrightAccessibilityJunitFile');
     expect(nightlySource.match(/publishPlaywrightAccessibilityJUnit\(\)/g)).toHaveLength(1);
   });
 


### PR DESCRIPTION
### Jira link

N/A — nightly pipeline reliability fix.

### Change description

Accessibility tests continue to run and publish their JUnit/HTML reports, but accessibility test failures no longer mark the nightly Jenkins build unstable. Other test lanes and publisher behavior are unchanged.

### Dependency PRs

N/A

### Testing done

Automated:

- [x] `yarn playwright test playwright_tests_new/api/unit/jenkins-playwright-reporting.unit.api.ts --project node-api` — 9 passed, 0 flaky.
- [x] Falsification: temporarily restored the old JUnit publisher line — the new contract test failed as expected; the working tree was then restored.
- [x] `git diff --check` — passed.

Manual:

- [ ] Jenkins nightly validation — to be run after merge to master.

Evidence:

- HTML: N/A
- Odhin: local focused test output generated during validation.
- JUnit: N/A

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (not needed for this pipeline-only change)
- [x] tests have been updated / new tests has been added (contract assertion added)
- [x] Does this PR introduce a breaking change — No
- [x] Can this PR be released on a Friday (ie: no functional code changes)
